### PR TITLE
Update Python versions, remove 3.4 & 3.5, add 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # Config file for automatic testing at travis-ci.org
+dist: xenial   # required for Python >= 3.7
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
+  - "3.7"
 
 # command to install dependencies
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,9 @@ environment:
   matrix:
     - PYTHON_VERSION: 2.7
       MINICONDA: C:\Miniconda
-    - PYTHON_VERSION: 3.4
-      MINICONDA: C:\Miniconda3
-    - PYTHON_VERSION: 3.5
-      MINICONDA: C:\Miniconda3
     - PYTHON_VERSION: 3.6
+      MINICONDA: C:\Miniconda3
+    - PYTHON_VERSION: 3.7
       MINICONDA: C:\Miniconda3
 
 init:

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -1,4 +1,5 @@
 # Config file for automatic testing at travis-ci.org
+dist: xenial   # required for Python >= 3.7
 language: python
 python:
 {%- if cookiecutter.Python_version == 'Python 2 and 3' or cookiecutter.Python_version == 'Python 2' %}

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -5,9 +5,8 @@ python:
   - "2.7"
 {%- endif %}
 {%- if cookiecutter.Python_version == 'Python 3' or cookiecutter.Python_version == 'Python 2 and 3' %}
-  - "3.4"
-  - "3.5"
   - "3.6"
+  - "3.7"
 {%- endif %}
 
 # command to install dependencies

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -37,9 +37,8 @@ This repository is set up with Python versions:
 * 2.7
 {%- endif %}
 {%- if cookiecutter.Python_version == 'Python 3' or cookiecutter.Python_version == 'Python 2 and 3' %}
-* 3.4
-* 3.5
 * 3.6
+* 3.7
 {%- endif %}
 
 Add or remove Python versions based on project requirements. `The guide <https://guide.esciencecenter.nl/best_practices/language_guides/python.html>`_ contains more information about Python versions and writing Python 2 and 3 compatible code.

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -54,9 +54,8 @@ setup(
 {%- endif %}
 {%- if cookiecutter.Python_version == 'Python 3' or cookiecutter.Python_version == 'Python 2 and 3' %}
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
 {%- endif %}
     ],
     test_suite='tests',


### PR DESCRIPTION
3.7 should be added, just because it's the latest stable release for a while now. I think 3.8 should be released pretty soon, so that should be added then as well.

I think we can safely drop 3.4 and 3.5. I just ran into issues with both: in 3.4, Sphinx can no longer be used (2.1.1 requires at least Python 3.5 to run) and in 3.5 Matplotlib, one of our core dependencies, has the same issue, its latest version only still works for 3.6 or higher.