### PR TITLE
Replace appveyor Conda setup with simple Pip setup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,48 +1,21 @@
-build: false
+build: off
 
 environment:
 
   matrix:
-    - PYTHON_VERSION: 3.5
-      MINICONDA: C:\Miniconda3
-    - PYTHON_VERSION: 3.6
-      MINICONDA: C:\Miniconda3
-    # Fails because of unsatisfiable requirements
-    #- PYTHON_VERSION: 3.7
-    #  MINICONDA: C:\Miniconda3
+
+    - PYTHON: C:\Python35
+    - PYTHON: C:\Python36
+    - PYTHON: C:\Python37
 
 init:
-  - "ECHO %PYTHON_VERSION% %MINICONDA%"
+  - "ECHO %PYTHON%"
 
 install:
-  # Issues have been encountered with installing numpy and scipy on
-  # AppVeyor e.g.
-  # http://tjelvarolsson.com/blog/how-to-continuously-test-your-python-code-on-windows-using-appveyor/
-  # Miniconda is recommended as the way to install these. See also:
-  # https://github.com/appveyor/ci/issues/359
-  # The following adopts approaches suggested in the above links.
-  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
-  - conda config --set always_yes yes --set changeps1 no
-  - conda config --prepend channels conda-forge
-  - conda update -q conda
-  - conda info -a
-  - "conda create -q -n test-environment python=%PYTHON_VERSION%
-    pytest
-    cookiecutter
-    pytest
-    pytest-cookies
-    pycodestyle
-    ruamel.yaml"
-  - activate test-environment
-  # Print the environment.
-  - which python
-  - which pip
-  - which py.test
-  - pytest --version
-  - python --version
-  - pip freeze
+  - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
 
 test_script:
+  - set PATH=%PYTHON%\\Scripts
   # Run py.test with 'v' (verbose) to show test function names and
   # 'rs' to show reasons for skipped tests
-- pytest -v -rs
+  - "pytest -v -rs"


### PR DESCRIPTION
Since there is no need for external libraries such as NumPy and SciPy,
we can simply use pip to install our requirements.

This automatically fixes the missing `sh` installation (admittedly, this doesn't run on Windows anyway), and allows for Python 3.7 to be tested with the template.

This also makes the Appveyor configuration closer to the Travis configuration, which isn't needed, but may be nice for reference.

There are probably nicer ways to set up the AppVeyor configuration, but I'm not too familiar with either AppVeyor or Windows; I based the current configuration on the template given at https://packaging.python.org/guides/supporting-windows-using-appveyor/

