### PR TITLE
remove requirements.txt and all references to it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ python:
   - "3.6"
   - "3.7"
 
-# command to install dependencies
+# command to install package
 install:
-  - pip install -r requirements.txt
+  - pip install .
 
 # command to run tests
 script: pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Python 3.5 support in the generated project
 * Run template tests for Python 3.7 on appveyor
 * Badge table (#52 and #57)
+* Remove requirements.txt (discussion: https://github.com/NLeSC/guide/issues/156)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ path/to/package/
 │   └── package.py
 ├── README.rst
 ├── project_setup.rst
-├── requirements.txt
 ├── setup.cfg
 ├── setup.py
 └── tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ init:
   - "ECHO %PYTHON%"
 
 install:
-  - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
+  - "%PYTHON%\\python.exe -m pip install ."
 
 test_script:
   - set PATH=%PYTHON%\\Scripts

--- a/{{cookiecutter.project_slug}}/.github/workflows/build.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
         run: |
           which python
           python --version
-      - name: Install dependencies
+      - name: Install package and its dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install .
       - name: Check style against standards using prospector
         shell: bash -l {0}
         run: prospector -o grouped -o pylint:pylint-report.txt


### PR DESCRIPTION
This includes all CI commands where it was used to only install dependencies, which was an empty list though. Now they all install the package through setup.py.

Fixes #67.