### PR TITLE
Fix CI build with simpler installation

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/build.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/build.yml
@@ -27,13 +27,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Check style against standards using prospector
-        shell: bash -l {0}
-        run: prospector -o grouped -o pylint:pylint-report.txt
       - name: Build
         shell: bash -l {0}
         run: |
-          python setup.py build
+          pip install -e .[dev]
+      - name: Check style against standards using prospector
+        shell: bash -l {0}
+        run: prospector -0 -o grouped -o pylint:pylint-report.txt
       - name: Test
         shell: bash -l {0}
         run: |

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -6,6 +6,12 @@ from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 
+test_deps = [
+    'pytest',
+    'pytest-cov',
+    'pycodestyle',
+]
+
 # To update the package version number, edit CITATION.cff
 with open('CITATION.cff', 'r') as cff:
     for line in cff:
@@ -62,13 +68,9 @@ setup(
         'sphinx_rtd_theme',
         'recommonmark'
     ],
-    tests_require=[
-        'pytest',
-        'pytest-cov',
-        'pycodestyle',
-    ],
+    tests_require=test_deps,
     extras_require={
-        'dev':  ['prospector[with_pyroma]', 'yapf', 'isort'],
+        'dev':  ['prospector[with_pyroma]', 'yapf', 'isort'] + test_deps,
     },
     data_files=[('citation/{{ cookiecutter.project_slug.lower().replace(' ', '_').replace('-', '_')}}', ['CITATION.cff'])]
 )


### PR DESCRIPTION
Some changes to fix #74 :
* all development packages can now be installed with `pip install .[dev]`
* First install the package, then run prospector
* Use the `-0` option of prospector so that it doesn't fail the build with style errors