### PR TITLE
switched to using static metadata

### DIFF
--- a/{{cookiecutter.project_slug}}/MANIFEST.in
+++ b/{{cookiecutter.project_slug}}/MANIFEST.in
@@ -1,2 +1,3 @@
+include CITATION.cff
 include LICENSE
 include README.rst

--- a/{{cookiecutter.project_slug}}/MANIFEST.in
+++ b/{{cookiecutter.project_slug}}/MANIFEST.in
@@ -1,3 +1,4 @@
 include CITATION.cff
 include LICENSE
+include NOTICE
 include README.rst

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -1,5 +1,64 @@
+# see documentation, e.g.
+# - https://packaging.python.org/tutorials/packaging-projects/#configuring-metadata
+# - https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html
+# - https://www.python.org/dev/peps/pep-0314/
+
 [metadata]
-description-file = README.rst
+author = {{ cookiecutter.full_name }}
+author_email = {{ cookiecutter.email }}
+classifiers =
+    Development Status :: 2 - Pre-Alpha
+    Intended Audience :: Developers
+    {{ {"Apache Software License 2.0": "License :: OSI Approved :: Apache Software License",
+        "MIT license": "License :: OSI Approved :: MIT License",
+        "BSD license": "License :: OSI Approved :: BSD License",
+        "ISC license": "License :: OSI Approved :: ISC License (ISCL)",
+        "GNU General Public License v3 or later": "License :: OSI Approved :: GNU General Public License",
+        "Not open source": "License :: Other/Proprietary License"
+    }[cookiecutter.open_source_license] }}
+    Natural Language :: English
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+description = {{ cookiecutter.project_short_description }}
+long_description = file: README.md
+long_description_content_type = text/markdown
+name = {{ cookiecutter.project_slug.lower().replace(" ", "_").replace("-", "_")}}
+project_urls =
+    Bug Tracker = https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug.lower().replace(" ", "_").replace("-", "_") }}/issues
+url = "https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug.lower().replace(" ", "_").replace("-", "_") }}
+version = {{ cookiecutter.version }}
+
+
+[options]
+zip_safe = False
+include_package_data = True
+packages =
+    {{ cookiecutter.project_slug.lower().replace(" ", "_").replace("-", "_")}}
+install_requires =
+
+
+[options.extras_require]
+dev =
+    prospector[with_pyroma]
+    yapf
+    isort
+    pytest
+    pytest-cov
+    pycodestyle
+    docutils
+    pytest-runner
+    sphinx
+    sphinx_rtd_theme
+    recommonmark
+
+[options.data_files]
+# This section requires setuptools>=40.6.0
+# It remains empty for now
+# Check if MANIFEST.in works for your purposes
+
 
 [aliases]
 # Define `python setup.py test`

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -1,75 +1,7 @@
 #!/usr/bin/env python
 import os
-
 from setuptools import setup
 
-here = os.path.abspath(os.path.dirname(__file__))
 
-# To update the package version number, edit CITATION.cff
-with open("CITATION.cff", "r") as cff:
-    for line in cff:
-        if "version:" in line:
-            version = line.replace("version:", "").strip().strip('"')
-
-with open("README.rst") as readme_file:
-    readme = readme_file.read()
-
-{%- set license_classifiers = {
-    "MIT license": "License :: OSI Approved :: MIT License",
-    "BSD license": "License :: OSI Approved :: BSD License",
-    "ISC license": "License :: OSI Approved :: ISC License (ISCL)",
-    "Apache Software License 2.0": "License :: OSI Approved :: Apache Software License",
-    "GNU General Public License v3 or later": "License :: OSI Approved :: GNU General Public License"
-} %}
-
-setup(
-    name="{{ cookiecutter.project_slug.lower().replace(" ", "_").replace("-", "_")}}",
-    version=version,
-    description="{{ cookiecutter.project_short_description.replace('\"', '\\\"') }}",
-    long_description=readme + "\n\n",
-    author="{{ cookiecutter.full_name.replace('\"', '\\\"') }}",
-    author_email="{{ cookiecutter.email }}",
-    url="https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug.lower().replace(" ", "_").replace("-", "_")}}",
-    packages=[
-        "{{ cookiecutter.project_slug.lower().replace(" ", "_").replace("-", "_")}}",
-    ],
-    include_package_data=True,
-{%- if cookiecutter.open_source_license in license_classifiers %}
-    license="{{ cookiecutter.open_source_license }}",
-{%- endif %}
-    zip_safe=False,
-    keywords="{{ cookiecutter.project_slug }}",
-    classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
-        "Intended Audience :: Developers",
-{%- if cookiecutter.open_source_license in license_classifiers %}
-        "{{ license_classifiers[cookiecutter.open_source_license] }}",
-{%- endif %}
-        "Natural Language :: English",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9"
-    ],
-    test_suite="tests",
-    install_requires=[],  # FIXME: add your package's dependencies to this list
-    setup_requires=[],
-    tests_require=[],
-    extras_require={
-        "dev": [
-            "prospector[with_pyroma]",
-            "yapf",
-            "isort",
-            "pytest",
-            "pytest-cov",
-            "pycodestyle",
-            "docutils",
-            "pytest-runner",
-            "sphinx",
-            "sphinx_rtd_theme",
-            "recommonmark"
-        ],
-    },
-    data_files=[("citation/{{ cookiecutter.project_slug.lower().replace(" ", "_").replace("-", "_")}}", ["CITATION.cff"])]
-)
+# see setup.cfg
+setup()


### PR DESCRIPTION
In this PR, I switched the configuration from setup.py over to a static configuration in setup.cfg as per the recommended best practices.

Refs #84

Note that our use of `data_files` requires a `setuptools>=40.6.0`, my installation did not meet that out of the box, so had to do `pip install --upgrade setuptools`

Assuming you have cookiecutter installed in user space, test with:

```shell
cd $(mktemp -d --tmpdir python-template.XXXXXX)
git clone https://github.com/NLeSC/python-template.git
cd python-template
git checkout 84-static-metadata
cd ..

cookiecutter python-template
# answer the questions by pressing enter for default answers

cd my_python_project
python3 -m venv env
source env/bin/activate
pip install --upgrade pip
pip install --upgrade wheel
pip install --upgrade setuptools

# this next step should now work:
pip install .[dev]

# should run but has failing tests
pytest

# should build a source distribution 
python setup.py sdist 

# check tar contents
cd dist && tar -xvzf my_python_project-0.1.0.tar.gz
my_python_project-0.1.0/
my_python_project-0.1.0/setup.py
my_python_project-0.1.0/my_python_project/
my_python_project-0.1.0/my_python_project/__version__.py
my_python_project-0.1.0/my_python_project/__init__.py
my_python_project-0.1.0/my_python_project/my_python_project.py
my_python_project-0.1.0/NOTICE
my_python_project-0.1.0/setup.cfg
my_python_project-0.1.0/MANIFEST.in
my_python_project-0.1.0/README.rst
my_python_project-0.1.0/PKG-INFO
my_python_project-0.1.0/my_python_project.egg-info/
my_python_project-0.1.0/my_python_project.egg-info/SOURCES.txt
my_python_project-0.1.0/my_python_project.egg-info/dependency_links.txt
my_python_project-0.1.0/my_python_project.egg-info/not-zip-safe
my_python_project-0.1.0/my_python_project.egg-info/requires.txt
my_python_project-0.1.0/my_python_project.egg-info/PKG-INFO
my_python_project-0.1.0/my_python_project.egg-info/top_level.txt
my_python_project-0.1.0/CITATION.cff
my_python_project-0.1.0/LICENSE

cat my_python_project-0.1.0/PKG-INFO
Metadata-Version: 2.1
Name: my_python_project
Version: 0.1.0
Summary: UNKNOWN
Home-page: "https://github.com/<my-github-organization>/my_python_project
Author: John Smith
Author-email: yourname@esciencecenter.nl
License: UNKNOWN
Project-URL: Bug Tracker, https://github.com/<my-github-organization>/my_python_project/issues
Description: UNKNOWN
Platform: UNKNOWN
Classifier: Development Status :: 2 - Pre-Alpha
Classifier: Intended Audience :: Developers
Classifier: License :: OSI Approved :: Apache Software License
Classifier: Natural Language :: English
Classifier: Programming Language :: Python :: 3
Classifier: Programming Language :: Python :: 3.6
Classifier: Programming Language :: Python :: 3.7
Classifier: Programming Language :: Python :: 3.8
Classifier: Programming Language :: Python :: 3.9
Description-Content-Type: text/markdown
Provides-Extra: dev


```



