### PR TITLE
now using setup.py and setup.cfg instead of requirements.txt

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip setuptools
-        pip install .[dev]
+        python3 -m pip install .[dev]
     - name: Run tests
       run: |
         pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        python3 -m pip install --upgrade pip setuptools
+        pip install .[dev]
     - name: Run tests
       run: |
         pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-norecursedirs = .git .github hooks {{cookiecutter.project_name}}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-cookiecutter==1.7.2
-
-# Testing
-pytest<5.0.0,>=3.3.0
-pytest-cookies

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,50 @@
+# see documentation, e.g.
+# - https://packaging.python.org/tutorials/packaging-projects/#configuring-metadata
+# - https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html
+# - https://www.python.org/dev/peps/pep-0314/
+
+
+[metadata]
+author = Netherlands eScience Center
+classifiers =
+    Development Status :: 2 - Pre-Alpha
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Natural Language :: English
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+description = Cookiecutter template to initialize Python projects in accordance with Netherlands eScience Center best practices
+long_description = file: README.md
+long_description_content_type = text/markdown
+name = Netherlands eScience Center Python Template
+project_urls =
+    Bug Tracker = https://github.com/NLeSC/python-template/issues
+url = https://github.com/NLeSC/python-template
+version = 0.2.0
+
+
+[options]
+zip_safe = False
+include_package_data = True
+packages =
+install_requires =
+    cookiecutter==1.7.2
+
+[options.data_files]
+# This section requires setuptools>=40.6.0
+# It remains empty for now
+# Check if MANIFEST.in works for your purposes
+
+
+[options.extras_require]
+dev =
+    pytest<5.0.0,>=3.3.0
+    pytest-cookies
+
+
+[tool:pytest]
+testpaths = tests
+norecursedirs = .git .github hooks {{cookiecutter.project_name}}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+import os
+from setuptools import setup
+
+
+# see setup.cfg
+setup()


### PR DESCRIPTION
In this PR:

- replaced requirements.txt with setup.cfg|py
- removed pytest.ini
- updated github action workflow

Refs:

- #141: setup.py|cfg
- #155: remove pytest.ini
