### PR TITLE
added bump2version dep and config

### DIFF
--- a/{{cookiecutter.project_name}}/.bumpversion.cfg
+++ b/{{cookiecutter.project_name}}/.bumpversion.cfg
@@ -1,0 +1,17 @@
+[bumpversion]
+current_version = {{ cookiecutter.version }}
+
+[comment]
+comment = The contents of this file cannot be merged with that of setup.cfg until https://github.com/c4urself/bump2version/issues/185 is resolved
+
+[bumpversion:file:{{ cookiecutter.package_name }}/__version__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:setup.cfg]
+search = version = {current_version}
+replace = version = {new_version}
+
+[bumpversion:file:CITATION.cff]
+search = version: "{current_version}"
+replace = version: "{new_version}"

--- a/{{cookiecutter.project_name}}/project_setup.md
+++ b/{{cookiecutter.project_name}}/project_setup.md
@@ -105,7 +105,7 @@ help you decide which tool to use for packaging.
 ## Package version number
 
 - We recommend using [semantic versioning](https://guide.esciencecenter.nl/#/best_practices/releases?id=semantic-versioning).
-- For convenience, the package version is stored in a single place: `{{ cookiecutter.package_name }}/.bumpversion.cfg`.
+- For convenience, the package version is stored in a single place: `{{ cookiecutter.project_name }}/.bumpversion.cfg`.
   For updating the version number, make sure the dev dependencies are installed and run `bumpversion patch`,
   `bumpversion minor`, or `bumpversion major` as appropriate.
 - Don't forget to update the version number before [making a release](https://guide.esciencecenter.nl/#/best_practices/releases)!

--- a/{{cookiecutter.project_name}}/project_setup.md
+++ b/{{cookiecutter.project_name}}/project_setup.md
@@ -105,8 +105,9 @@ help you decide which tool to use for packaging.
 ## Package version number
 
 - We recommend using [semantic versioning](https://guide.esciencecenter.nl/#/best_practices/releases?id=semantic-versioning).
-- For convenience, the package version is stored in a single place: `{{ cookiecutter.package_name }}/__version__.py`.
-  For updating the version number, you only have to change this file.
+- For convenience, the package version is stored in a single place: `{{ cookiecutter.package_name }}/.bumpversion.cfg`.
+  For updating the version number, make sure the dev dependencies are installed and run `bumpversion patch`,
+  `bumpversion minor`, or `bumpversion major` as appropriate.
 - Don't forget to update the version number before [making a release](https://guide.esciencecenter.nl/#/best_practices/releases)!
 
 ## Publish on Python Package Index (PyPI)

--- a/{{cookiecutter.project_name}}/setup.cfg
+++ b/{{cookiecutter.project_name}}/setup.cfg
@@ -3,6 +3,20 @@
 # - https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html
 # - https://www.python.org/dev/peps/pep-0314/
 
+[bumpversion]
+current_version = {{ cookiecutter.version }}
+
+[bumpversion:file:{{ cookiecutter.package_name }}/__version__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:setup.cfg]
+search = version = {current_version}
+replace = version = {new_version}
+
+[bumpversion:file:CITATION.cff]
+search = version: "{current_version}"
+replace = version: "{new_version}"
 
 [metadata]
 author = {{ cookiecutter.full_name }}
@@ -32,7 +46,6 @@ project_urls =
 url = {{ cookiecutter.repository }}
 version = {{ cookiecutter.version }}
 
-
 [options]
 zip_safe = False
 include_package_data = True
@@ -40,15 +53,14 @@ packages =
     {{ cookiecutter.package_name }}
 install_requires =
 
-
 [options.data_files]
 # This section requires setuptools>=40.6.0
 # It remains empty for now
 # Check if MANIFEST.in works for your purposes
 
-
 [options.extras_require]
 dev =
+    bump2version
     prospector[with_pyroma]
     yapf
     isort
@@ -61,11 +73,9 @@ dev =
     sphinx_rtd_theme
     recommonmark
 
-
 [coverage:run]
 branch = True
 source = {{ cookiecutter.package_name }}
-
 
 [tool:isort]
 lines_after_imports = 2
@@ -74,7 +84,6 @@ no_lines_before = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 known_first_party = {{ cookiecutter.package_name }}
 src_paths = {{ cookiecutter.package_name }},tests
 line_length = 120
-
 
 [tool:pytest]
 testpaths = tests

--- a/{{cookiecutter.project_name}}/setup.cfg
+++ b/{{cookiecutter.project_name}}/setup.cfg
@@ -3,21 +3,6 @@
 # - https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html
 # - https://www.python.org/dev/peps/pep-0314/
 
-[bumpversion]
-current_version = {{ cookiecutter.version }}
-
-[bumpversion:file:{{ cookiecutter.package_name }}/__version__.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"
-
-[bumpversion:file:setup.cfg]
-search = version = {current_version}
-replace = version = {new_version}
-
-[bumpversion:file:CITATION.cff]
-search = version: "{current_version}"
-replace = version: "{new_version}"
-
 [metadata]
 author = {{ cookiecutter.full_name }}
 author_email = {{ cookiecutter.email }}

--- a/{{cookiecutter.project_name}}/setup.cfg
+++ b/{{cookiecutter.project_name}}/setup.cfg
@@ -72,4 +72,6 @@ line_length = 120
 
 [tool:pytest]
 testpaths = tests
+# Note that visual debugger in some editors like pycharm gets confused by coverage calculation.
+# As a workaround, configure the test configuration in pycharm et al with a --no-cov argument
 addopts = --cov --cov-report xml --cov-report term --cov-report html


### PR DESCRIPTION
refs #192

Note: for some reason, it reformats `setup.cfg` if you run bump2version in the generated project. Apparently a known issue: https://github.com/c4urself/bump2version/issues/185

In the process of rewriting all of setup.cfg, it also removes comments that we added there to point to relevant documentation
