### PR TITLE
Use encoding instead of text

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -17,7 +17,7 @@ def run(command: str, dirpath: os.PathLike) -> subprocess.CompletedProcess:
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE,
                           cwd=dirpath,
-                          encoding='utf-8')
+                          encoding="utf-8")
 
 
 def test_pytest(cookies):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -17,7 +17,7 @@ def run(command: str, dirpath: os.PathLike) -> subprocess.CompletedProcess:
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE,
                           cwd=dirpath,
-                          text=True)
+                          encoding='utf-8')
 
 
 def test_pytest(cookies):


### PR DESCRIPTION
Dont use text argument as was introduced in Python 3.7 while template is for 3.6

Fixes #188