### PR TITLE
Added GHA workflow to add issues which should be performed after cook…

### DIFF
--- a/{{cookiecutter.project_name}}/.github/next_steps/01_sonarcloud_integration.md
+++ b/{{cookiecutter.project_name}}/.github/next_steps/01_sonarcloud_integration.md
@@ -1,0 +1,18 @@
+---
+title: 'Next step: Sonarcloud integration'
+labels: enhancement
+---
+
+Continuous code quality can be handled by many services for `NLeSC/python-template` we chose [Sonarcloud](https://sonarcloud.io/).
+[Sonarcloud](https://sonarcloud.io/) is used to perform quality analysis and code coverage report on each push.
+
+Sonarcloud must be configured for the analysis to work
+
+1. go to [Sonarcloud](https://sonarcloud.io/projects/create)
+2. login with your GitHub account
+3. add organization or reuse existing one
+4. set up repository
+5. go to [new code definition administration page](https://sonarcloud.io/project/new_code?id={{ cookiecutter.github_organization }}_{{ cookiecutter.project_name }}) and select `Number of days` option
+
+The analysis will be run by [GitHub Action workflow](.github/workflows/sonarcloud.yml)
+To be able to run the analysis, a token must be created at [Sonarcloud account](https://sonarcloud.io/account/security/) and this token must be added as `SONAR_TOKEN` to [secrets on GitHub](https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecutter.project_name }}/settings/secrets/actions)

--- a/{{cookiecutter.project_name}}/.github/next_steps/01_sonarcloud_integration.md
+++ b/{{cookiecutter.project_name}}/.github/next_steps/01_sonarcloud_integration.md
@@ -1,7 +1,6 @@
 ---
 title: 'Next step: Sonarcloud integration'
 labels: 
-  - 'enhancement'
   - 'action required'
 ---
 

--- a/{{cookiecutter.project_name}}/.github/next_steps/01_sonarcloud_integration.md
+++ b/{{cookiecutter.project_name}}/.github/next_steps/01_sonarcloud_integration.md
@@ -1,18 +1,17 @@
 ---
-title: 'Next step: Sonarcloud integration'
+title: 'Action required: Sonarcloud integration'
 labels: enhancement
 ---
 
-Continuous code quality can be handled by many services for `NLeSC/python-template` we chose [Sonarcloud](https://sonarcloud.io/).
-[Sonarcloud](https://sonarcloud.io/) is used to perform quality analysis and code coverage report on each push.
+Continuous code quality can be handled by [Sonarcloud](https://sonarcloud.io/). This repository is configured to use Sonarcloud to perform quality analysis and code coverage report on each push.
 
-Sonarcloud must be configured for the analysis to work
+In order to configure Sonarcloud analysis [GitHub Action workflow](.github/workflows/sonarcloud.yml) you must follow the steps below:
 
-1. go to [Sonarcloud](https://sonarcloud.io/projects/create)
-2. login with your GitHub account
-3. add organization or reuse existing one
-4. set up repository
-5. go to [new code definition administration page](https://sonarcloud.io/project/new_code?id={{ cookiecutter.github_organization }}_{{ cookiecutter.project_name }}) and select `Number of days` option
-
-The analysis will be run by [GitHub Action workflow](.github/workflows/sonarcloud.yml)
-To be able to run the analysis, a token must be created at [Sonarcloud account](https://sonarcloud.io/account/security/) and this token must be added as `SONAR_TOKEN` to [secrets on GitHub](https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecutter.project_name }}/settings/secrets/actions)
+1. go to [Sonarcloud](https://sonarcloud.io/projects/create) to create a new Sonarcloud project
+1. login with your GitHub account
+1. add Sonarcloud organization or reuse existing one
+1. set up a repository
+1. go to [new code definition administration page](https://sonarcloud.io/project/new_code?id={{ cookiecutter.github_organization }}_{{ cookiecutter.project_name }}) and select `Number of days` option
+1. To be able to run the analysis:
+   1. a token must be created at [Sonarcloud account](https://sonarcloud.io/account/security/)
+   1. the created token must be added as `SONAR_TOKEN` to [secrets on GitHub](https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecutter.project_name }}/settings/secrets/actions)

--- a/{{cookiecutter.project_name}}/.github/next_steps/01_sonarcloud_integration.md
+++ b/{{cookiecutter.project_name}}/.github/next_steps/01_sonarcloud_integration.md
@@ -1,6 +1,8 @@
 ---
-title: 'Action required: Sonarcloud integration'
-labels: enhancement
+title: 'Next step: Sonarcloud integration'
+labels: 
+  - 'enhancement'
+  - 'action required'
 ---
 
 Continuous code quality can be handled by [Sonarcloud](https://sonarcloud.io/). This repository is configured to use Sonarcloud to perform quality analysis and code coverage report on each push.

--- a/{{cookiecutter.project_name}}/.github/next_steps/02_zenodo_integration.md
+++ b/{{cookiecutter.project_name}}/.github/next_steps/02_zenodo_integration.md
@@ -1,0 +1,7 @@
+---
+title: 'Next step: Zenodo integration'
+labels:
+  - 'action required'
+---
+
+Zenodo integration instructions.

--- a/{{cookiecutter.project_name}}/.github/next_steps/03_readthedocs.md
+++ b/{{cookiecutter.project_name}}/.github/next_steps/03_readthedocs.md
@@ -1,0 +1,7 @@
+---
+title: 'Next step: readthedocs'
+labels:
+  - 'action required'
+---
+
+Readthedocs instructions.

--- a/{{cookiecutter.project_name}}/.github/next_steps/04_citation.md
+++ b/{{cookiecutter.project_name}}/.github/next_steps/04_citation.md
@@ -1,0 +1,7 @@
+---
+title: 'Next step: Citation data'
+labels:
+  - 'action required'
+---
+
+Citation data instructions

--- a/{{cookiecutter.project_name}}/.github/next_steps/05_linting.md
+++ b/{{cookiecutter.project_name}}/.github/next_steps/05_linting.md
@@ -1,0 +1,7 @@
+---
+title: 'Next step: Linting'
+labels:
+  - 'action required'
+---
+
+Linting instructions

--- a/{{cookiecutter.project_name}}/.github/next_steps/labels.yml
+++ b/{{cookiecutter.project_name}}/.github/next_steps/labels.yml
@@ -1,0 +1,3 @@
+- name: "action required"
+  color: "207909"
+  description: "Issues that should be completed to get a fully working Python package with all the bells and whistles"

--- a/{{cookiecutter.project_name}}/.github/next_steps/labels.yml
+++ b/{{cookiecutter.project_name}}/.github/next_steps/labels.yml
@@ -1,3 +1,3 @@
 - name: "action required"
   color: "207909"
-  description: "Issues that should be completed to get a fully working Python package with all the bells and whistles"
+  description: "Issues that should be completed to get a fully working Python package"

--- a/{{cookiecutter.project_name}}/.github/workflows/next_steps.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/next_steps.yml
@@ -1,0 +1,31 @@
+on: [push]
+name: Create issues for next steps
+jobs:
+  next_steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create Sonarcloud integration issue
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/next_steps/01_sonarcloud_integration.md
+        id: sonarcloud
+      - name: List created issues
+        run: |
+          echo 'Created issues that must be completed to have fully working Python package:'
+          echo '* ${{ steps.sonarcloud.outputs.url }}'
+          echo '* ${{ steps.sonarcloud.outputs.url }}'
+          echo '* ${{ steps.sonarcloud.outputs.url }}'
+          echo '* ${{ steps.sonarcloud.outputs.url }}'
+          echo '* ${{ steps.sonarcloud.outputs.url }}'
+          echo '* ${{ steps.sonarcloud.outputs.url }}'
+      - name: Cleanup files needed to create next steps issues
+        run: |
+          git config --global user.name 'Your Name'
+          git config --global user.email 'your-username@users.noreply.github.com'
+          git rm .github/workflows/next_steps.yml
+          git rm -r .github/next_steps
+          git commit -am "Cleanup automated next step issue generator"
+          git push

--- a/{{cookiecutter.project_name}}/.github/workflows/next_steps.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/next_steps.yml
@@ -56,8 +56,8 @@ jobs:
           * Linting fixes ${{ steps.linting.outputs.url }}' | tee -a next_steps.md
       - name: Cleanup files needed to create next steps issues
         run: |
-          git config --global user.name 'Your Name'
-          git config --global user.email 'your-username@users.noreply.github.com'
+          git config --global user.name 'NLeSC Python template'
+          git config --global user.email 'nlesc-python-template@users.noreply.github.com'
           git add next_steps.md
           git rm .github/workflows/next_steps.yml
           git rm -r .github/next_steps

--- a/{{cookiecutter.project_name}}/.github/workflows/next_steps.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/next_steps.yml
@@ -53,12 +53,11 @@ jobs:
           * Zenodo integration ${{ steps.zenodo.outputs.url }}
           * Readthedocs instructions ${{ steps.readthedocs.outputs.url }}
           * Citation data ${{ steps.citation.outputs.url }}
-          * Linting fixes ${{ steps.linting.outputs.url }}' | tee -a next_steps.md
+          * Linting fixes ${{ steps.linting.outputs.url }}'
       - name: Cleanup files needed to create next steps issues
         run: |
           git config --global user.name 'NLeSC Python template'
           git config --global user.email 'nlesc-python-template@users.noreply.github.com'
-          git add next_steps.md
           git rm .github/workflows/next_steps.yml
           git rm -r .github/next_steps
           git commit -am "Cleanup automated next steps issue generator"

--- a/{{cookiecutter.project_name}}/.github/workflows/next_steps.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/next_steps.yml
@@ -48,12 +48,12 @@ jobs:
         id: linting
       - name: List created issues
         run: |
-          echo 'Created issues that must be completed to have fully working Python package:' | tee -a next_steps.md
-          echo '* ${{ steps.sonarcloud.outputs.url }}' | tee -a next_steps.md
-          echo '* ${{ steps.zenodo.outputs.url }}' | tee -a next_steps.md
-          echo '* ${{ steps.readthedocs.outputs.url }}' | tee -a next_steps.md
-          echo '* ${{ steps.citation.outputs.url }}' | tee -a next_steps.md
-          echo '* ${{ steps.linting.outputs.url }}' | tee -a next_steps.md
+          echo 'Created issues that must be completed to have fully working Python package:
+          * Sonarcloud integration ${{ steps.sonarcloud.outputs.url }}
+          * Zenodo integration ${{ steps.zenodo.outputs.url }}
+          * Readthedocs instructions ${{ steps.readthedocs.outputs.url }}
+          * Citation data ${{ steps.citation.outputs.url }}
+          * Linting fixes ${{ steps.linting.outputs.url }}' | tee -a next_steps.md
       - name: Cleanup files needed to create next steps issues
         run: |
           git config --global user.name 'Your Name'

--- a/{{cookiecutter.project_name}}/.github/workflows/next_steps.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/next_steps.yml
@@ -12,19 +12,47 @@ jobs:
         with:
           filename: .github/next_steps/01_sonarcloud_integration.md
         id: sonarcloud
+      - name: Create Zenodo integration issue
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/next_steps/02_zenodo_integration.md
+        id: zenodo
+      - name: Create readthedocs issue
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/next_steps/03_readthedocs.md
+        id: readthedocs
+      - name: Create citation data issue
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/next_steps/04_citation.md
+        id: citation
+      - name: Create linting issue
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/next_steps/05_linting.md
+        id: linting
       - name: List created issues
         run: |
-          echo 'Created issues that must be completed to have fully working Python package:'
-          echo '* ${{ steps.sonarcloud.outputs.url }}'
-          echo '* ${{ steps.sonarcloud.outputs.url }}'
-          echo '* ${{ steps.sonarcloud.outputs.url }}'
-          echo '* ${{ steps.sonarcloud.outputs.url }}'
-          echo '* ${{ steps.sonarcloud.outputs.url }}'
-          echo '* ${{ steps.sonarcloud.outputs.url }}'
+          echo 'Created issues that must be completed to have fully working Python package:' | tee -a next_steps.md
+          echo '* ${{ steps.sonarcloud.outputs.url }}' | tee -a next_steps.md
+          echo '* ${{ steps.zenodo.outputs.url }}' | tee -a next_steps.md
+          echo '* ${{ steps.readthedocs.outputs.url }}' | tee -a next_steps.md
+          echo '* ${{ steps.citation.outputs.url }}' | tee -a next_steps.md
+          echo '* ${{ steps.linting.outputs.url }}' | tee -a next_steps.md
       - name: Cleanup files needed to create next steps issues
         run: |
           git config --global user.name 'Your Name'
           git config --global user.email 'your-username@users.noreply.github.com'
+          git add next_steps.md
           git rm .github/workflows/next_steps.yml
           git rm -r .github/next_steps
           git commit -am "Cleanup automated next step issue generator"

--- a/{{cookiecutter.project_name}}/.github/workflows/next_steps.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/next_steps.yml
@@ -5,6 +5,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Create labels
+        uses: crazy-max/ghaction-github-labeler@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/next_steps/labels.yml
+          skip-delete: true      
       - name: Create Sonarcloud integration issue
         uses: JasonEtco/create-an-issue@v2
         env:

--- a/{{cookiecutter.project_name}}/.github/workflows/next_steps.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/next_steps.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/next_steps/labels.yml
-          skip-delete: true      
+          skip-delete: true
       - name: Create Sonarcloud integration issue
         uses: JasonEtco/create-an-issue@v2
         env:
@@ -61,5 +61,5 @@ jobs:
           git add next_steps.md
           git rm .github/workflows/next_steps.yml
           git rm -r .github/next_steps
-          git commit -am "Cleanup automated next step issue generator"
+          git commit -am "Cleanup automated next steps issue generator"
           git push

--- a/{{cookiecutter.project_name}}/project_setup.md
+++ b/{{cookiecutter.project_name}}/project_setup.md
@@ -96,15 +96,10 @@ help you decide which tool to use for packaging.
 
 ## Continuous code quality
 
-- [Sonarcloud](https://sonarcloud.io/) is used to perform quality analysis and code coverage report on each push
-- Sonarcloud must be configured for the analysis to work
-  1. go to [Sonarcloud](https://sonarcloud.io/projects/create)
-  2. login with your GitHub account
-  3. add organization or reuse existing one
-  4. set up repository
-  5. go to [new code definition administration page](https://sonarcloud.io/project/new_code?id={{ cookiecutter.github_organization }}_{{ cookiecutter.project_name }}) and select `Number of days` option
-- The analysis will be run by [GitHub Action workflow](.github/workflows/sonarcloud.yml)
-- To be able to run the analysis, a token must be created at [Sonarcloud account](https://sonarcloud.io/account/security/) and this token must be added as `SONAR_TOKEN` to [secrets on GitHub](https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecutter.project_name }}/settings/secrets/actions)
+[Sonarcloud](https://sonarcloud.io/) is used to perform quality analysis and code coverage report
+
+- `sonar-project.properties` is the SonarCloud [configuration](https://docs.sonarqube.org/latest/analysis/analysis-parameters/) file
+- `.github/workflows/sonarcloud.yml` is the GitHub action workflow which performs the SonarCloud analysis
 
 ## Package version number
 


### PR DESCRIPTION
Refs: #228 #234 #239

**Summary:**
This pull request adds a GitHub Action workflow which creates issues for the next steps after pushing the generated package to GitHub.

**Details:**
- After the package is pushed to GitHub, the `{{cookiecutter.project_name}}/.github/workflows/next_steps.yml` workflow creates an issue for Sonarcloud. For other `next_steps` issues (see  #228 for the list) it creates an empty issue.
- The templates for the generated issues can be found in `{{cookiecutter.project_name}}/.github/next_steps/` folder.
- After successful completion the workflow removes itself and the `{{cookiecutter.project_name}}/.github/next_steps/` folder.
- The new issues have a `action required` label which is defined in {{cookiecutter.project_name}}/.github/next_steps/labels.yml

**Testing:**
- Create a new package
- Push your package to GitHub

**Note:** Please ignore Markdown link checker tests.

**Example:**
See https://github.com/fdiblen/bal