### PR TITLE
apidoc is no longer a question

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ cookiecutter https://github.com/nlesc/python-template.git
 | version                   | 0.1.0             | &nbsp; |
 | github_organization       | &lt;my-github-organization&gt; | GitHub organization that will contain this project's repository. This can also be your GitHub user name. |
 | license                   | Apache Software License 2.0 | The software license under which the code is made available.  |
-| apidoc                    | no                | Add support for automatically generating a module index from the `docstrings` in your Python package (look at the [scriptcwl package](http://scriptcwl.readthedocs.io/en/latest/apidocs/scriptcwl.html) for an example).
 | full_name                 | John Smith        | Your full name, e.g. _John Smith_. |
 | email                     | yourname@esciencecenter.nl | Your (work) email address. |
 | copyright_holder          | Netherlands eScience Center | Name(s) of the organization(s) or person(s) who hold the copyright of the software. |


### PR DESCRIPTION
This PR removes a row from the table in the template's README.md that referenced `apidoc` which has been removed in an earlier PR