### PR TITLE
At least make pytest on a Windows laptop work

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -26,7 +26,7 @@ def test_pytest(cookies):
     env_output = run(['python3', '-m', 'venv', 'env'], result.project)
     assert env_output.returncode == 0
     env_bin = 'env/Scripts/' if platform.startswith("win") else 'env/bin/'
-    latest_pip_output = run([f'{env_bin}pip3 install', '--upgrade', 'pip', 'setuptools'], result.project)
+    latest_pip_output = run([f'{env_bin}pip3', 'install', '--upgrade', 'pip', 'setuptools'], result.project)
     assert latest_pip_output.returncode == 0
     pip_output = run([f'{env_bin}pip3', 'install', '--editable', '.[dev]'], result.project)
     assert pip_output.returncode == 0


### PR DESCRIPTION
Uses list for args instead of parsing strings

Refs #223
Refs #200 

```
PS C:\Users\stefanv\git\NLeSC\python-template> .\env\Scripts\pytest.exe
==================================================== test session starts ====================================================
platform win32 -- Python 3.9.4, pytest-4.6.11, py-1.10.0, pluggy-0.13.1
rootdir: C:\Users\stefanv\git\NLeSC\python-template, inifile: setup.cfg, testpaths: tests
plugins: cookies-0.5.1, cov-2.11.1
collected 6 items

tests\test_project.py ..                                                                                         [ 33%]
tests\test_values.py ....                                                                                        [100%]

============================================== 6 passed in 21.51 seconds ==============================================
PS C:\Users\stefanv\git\NLeSC\python-template>
```