### PR TITLE
Subpackage support

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -38,7 +38,7 @@ def baked_withdevdeps(cookies):
 
 def test_pytest(baked_withdevdeps):
     project_dir, env_bin = baked_withdevdeps
-    pytest_output = run([f'{env_bin}pytest'], result.project)
+    pytest_output = run([f'{env_bin}pytest'], project_dir)
     assert pytest_output.returncode == 0
     assert '== 3 passed in' in pytest_output.stdout
     assert (project_dir / 'coverage.xml').exists()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -55,7 +55,7 @@ def test_subpackage(baked_withdevdeps):
     subsubpackage.mkdir()
     (subsubpackage / '__init__.py').write_text('FOO = "bar"', encoding="utf-8")
 
-    build_output = run('f'{env_bin}python3 setup.py build', project_dir)
+    build_output = run([f'{env_bin}python3', 'setup.py', 'build'], project_dir)
     assert build_output.returncode == 0
     assert (project_dir / 'build' / 'lib' / 'my_python_package' / 'mysub' / '__init__.py').exists()
     assert (project_dir / 'build' / 'lib' / 'my_python_package' / 'mysub' / 'mysub2' / '__init__.py').exists()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import shlex
 
+import pytest
+
 
 def test_project_folder(cookies):
     project = cookies.bake()
@@ -20,7 +22,8 @@ def run(command: str, dirpath: os.PathLike) -> subprocess.CompletedProcess:
                           encoding="utf-8")
 
 
-def test_pytest(cookies):
+@pytest.fixture
+def baked_withdevdeps(cookies):
     result = cookies.bake()
     env_output = run('python3 -m venv env', result.project)
     assert env_output.returncode == 0
@@ -28,9 +31,23 @@ def test_pytest(cookies):
     assert latest_pip_output.returncode == 0
     pip_output = run('env/bin/pip3 install --editable .[dev]', result.project)
     assert pip_output.returncode == 0
+    return result.project
 
-    pytest_output = run('env/bin/pytest', result.project)
+
+def test_pytest(baked_withdevdeps):
+    project_dir = baked_withdevdeps
+    pytest_output = run('env/bin/pytest', project_dir)
     assert pytest_output.returncode == 0
-    assert '== 3 passed in' in  pytest_output.stdout
-    assert (result.project / 'coverage.xml').exists()
-    assert (result.project / 'htmlcov/index.html').exists()
+    assert '== 3 passed in' in pytest_output.stdout
+    assert (project_dir / 'coverage.xml').exists()
+    assert (project_dir / 'htmlcov/index.html').exists()
+
+
+def test_subpackage(baked_withdevdeps):
+    project_dir = baked_withdevdeps
+    subpackage = (project_dir / 'my_python_package' / 'mysub')
+    subpackage.mkdir()
+    (subpackage / '__init__.py').write_text('FOO = "bar"', encoding="utf-8")
+    build_output = run('python3 setup.py build', project_dir)
+    assert build_output.returncode == 0
+    assert (project_dir / 'build' / 'lib' / 'my_python_package' / 'mysub' / '__init__.py').exists()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -48,6 +48,12 @@ def test_subpackage(baked_withdevdeps):
     subpackage = (project_dir / 'my_python_package' / 'mysub')
     subpackage.mkdir()
     (subpackage / '__init__.py').write_text('FOO = "bar"', encoding="utf-8")
+
+    subsubpackage = (project_dir / 'my_python_package' / 'mysub' / 'mysub2')
+    subsubpackage.mkdir()
+    (subsubpackage / '__init__.py').write_text('FOO = "bar"', encoding="utf-8")
+
     build_output = run('env/bin/python3 setup.py build', project_dir)
     assert build_output.returncode == 0
     assert (project_dir / 'build' / 'lib' / 'my_python_package' / 'mysub' / '__init__.py').exists()
+    assert (project_dir / 'build' / 'lib' / 'my_python_package' / 'mysub' / 'mysub2' / '__init__.py').exists()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -48,6 +48,6 @@ def test_subpackage(baked_withdevdeps):
     subpackage = (project_dir / 'my_python_package' / 'mysub')
     subpackage.mkdir()
     (subpackage / '__init__.py').write_text('FOO = "bar"', encoding="utf-8")
-    build_output = run('python3 setup.py build', project_dir)
+    build_output = run('env/bin/python3 setup.py build', project_dir)
     assert build_output.returncode == 0
     assert (project_dir / 'build' / 'lib' / 'my_python_package' / 'mysub' / '__init__.py').exists()

--- a/{{cookiecutter.project_name}}/setup.cfg
+++ b/{{cookiecutter.project_name}}/setup.cfg
@@ -61,7 +61,7 @@ publishing =
     wheel
 
 [options.packages.find]
-include = {{ cookiecutter.package_name }}, {{ cookiecutter.package_name }}*
+include = {{ cookiecutter.package_name }}, {{ cookiecutter.package_name }}.*
 
 [coverage:run]
 branch = True

--- a/{{cookiecutter.project_name}}/setup.cfg
+++ b/{{cookiecutter.project_name}}/setup.cfg
@@ -34,8 +34,7 @@ version = {{ cookiecutter.version }}
 [options]
 zip_safe = False
 include_package_data = True
-packages =
-    {{ cookiecutter.package_name }}
+packages = find:
 install_requires =
 
 [options.data_files]
@@ -57,9 +56,12 @@ dev =
     sphinx
     sphinx_rtd_theme
     recommonmark
-publishing = 
+publishing =
     twine
     wheel
+
+[options.packages.find]
+include = {{ cookiecutter.package_name }}, {{ cookiecutter.package_name }}*
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
Instead of populating `{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/` with a sub package I wrote a test that creates a subpakcage after running cookiecutter and verifies subpakcage is part of build.

Refs #160