### PR TITLE
Use package name as default for project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cookiecutter https://github.com/nlesc/python-template.git
 | Name                      | Default value | Explanation |
 | ------------------------- | ------------- | ----------- |
 | package_name              | my_python_package | Name of the package. Avoid using spaces, dashes, or uppercase letters for the best experience across operating systems. |
-| project_name              | my-python-project | Name of the project that contains the package. Avoid using spaces or uppercase letters for the best experience across operating systems. |
+| project_name              | my_python_package | Name of the project that contains the package. Avoid using spaces or uppercase letters for the best experience across operating systems. |
 | package_short_description | &nbsp;            | The information that you enter here will end up in the README, documentation, license, and setup.cfg, so it may be a good idea to prepare something in advance. |
 | version                   | 0.1.0             | &nbsp; |
 | github_organization       | &lt;my-github-organization&gt; | GitHub organization that will contain this project's repository. This can also be your GitHub user name. |

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "package_name": "my_python_package",
-  "project_name": "my-python-project",
+  "project_name": "{{ cookiecutter.package_name }}",
   "_copy_without_render": [".github/*"],
   "package_short_description": "",
   "version": "0.1.0",

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -11,7 +11,7 @@ def test_project_folder(cookies):
 
     assert project.exit_code == 0
     assert project.exception is None
-    assert project.project.basename == 'my-python-project'
+    assert project.project.basename == 'my_python_package'
     assert project.project.isdir()
 
 


### PR DESCRIPTION
Refs #211

Tested with
```
cookiecutter  ~/git/NLeSC/python-template
package_name [my_python_package]: ThisIsMyPreferredPackageName
project_name [ThisIsMyPreferredPackageName]: 
```