### PR TITLE
Add test for generating api docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest]
         python-version: ['3.6', '3.7', '3.8', '3.9']
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest]
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.6', '3.7', '3.8', '3.9']
     steps:
     - uses: actions/checkout@v2

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from pathlib import Path
+from shutil import which
 from sys import platform, executable
 from typing import Sequence
 
@@ -33,16 +34,17 @@ def baked_with_development_dependencies(cookies):
     if platform.startswith("win") and os.environ.get('CI', False):
         # Creating virtualenv does not work on Windows CI,
         # falling back to using current Python
-        bin_dir = str(Path(executable).parent) + '\\'
+        pip = Path(which('pip3'))
+        bin_dir = str(pip.parent) + '\\'
         print(bin_dir)
         print(list(Path(bin_dir).iterdir()))
     else:
         env_output = run(['python3', '-m', 'venv', 'env'], result.project)
         assert env_output.returncode == 0
         bin_dir = 'env/Scripts/' if platform.startswith("win") else 'env/bin/'
-    latest_pip_output = run([f'{bin_dir}pip', 'install', '--upgrade', 'pip', 'setuptools'], result.project)
+    latest_pip_output = run([f'{bin_dir}pip3', 'install', '--upgrade', 'pip', 'setuptools'], result.project)
     assert latest_pip_output.returncode == 0
-    pip_output = run([f'{bin_dir}pip', 'install', '--editable', '.[dev]'], result.project)
+    pip_output = run([f'{bin_dir}pip3', 'install', '--editable', '.[dev]'], result.project)
     assert pip_output.returncode == 0
     return result.project, bin_dir
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -35,7 +35,7 @@ def baked_with_development_dependencies(cookies):
         # falling back to using current Python
         bin_dir = str(Path(executable).parent) + '\\'
         print(bin_dir)
-        print(list(bin_dir.iterdir()))
+        print(list(Path(bin_dir).iterdir()))
     else:
         env_output = run(['python3', '-m', 'venv', 'env'], result.project)
         assert env_output.returncode == 0

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
-from sys import platform
+from pathlib import Path
+from sys import platform, executable
 from typing import Sequence
 
 import pytest
@@ -17,10 +18,10 @@ def test_project_folder(cookies):
 
 def run(args: Sequence[str], dirpath: os.PathLike) -> subprocess.CompletedProcess:
     completed_process = subprocess.run(args=args,
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE,
-                          cwd=dirpath,
-                          encoding="utf-8")
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE,
+                                       cwd=dirpath,
+                                       encoding="utf-8")
     print(completed_process.stdout)
     print(completed_process.stderr)
     return completed_process
@@ -29,19 +30,24 @@ def run(args: Sequence[str], dirpath: os.PathLike) -> subprocess.CompletedProces
 @pytest.fixture
 def baked_with_development_dependencies(cookies):
     result = cookies.bake()
-    env_output = run(['python3', '-m', 'venv', 'env'], result.project)
-    assert env_output.returncode == 0
-    env_bin = 'env/Scripts/' if platform.startswith("win") else 'env/bin/'
-    latest_pip_output = run([f'{env_bin}pip3', 'install', '--upgrade', 'pip', 'setuptools'], result.project)
+    if platform.startswith("win") and os.environ.get('CI', False):
+        # Creating virtualenv does not work on Windows CI,
+        # falling back to using current Python
+        bin_dir = str(Path(executable).parent) + '\\'
+    else:
+        env_output = run(['python3', '-m', 'venv', 'env'], result.project)
+        assert env_output.returncode == 0
+        bin_dir = 'env/Scripts/' if platform.startswith("win") else 'env/bin/'
+    latest_pip_output = run([f'{bin_dir}pip3', 'install', '--upgrade', 'pip', 'setuptools'], result.project)
     assert latest_pip_output.returncode == 0
-    pip_output = run([f'{env_bin}pip3', 'install', '--editable', '.[dev]'], result.project)
+    pip_output = run([f'{bin_dir}pip3', 'install', '--editable', '.[dev]'], result.project)
     assert pip_output.returncode == 0
-    return result.project, env_bin
+    return result.project, bin_dir
 
 
 def test_pytest(baked_with_development_dependencies):
-    project_dir, env_bin = baked_with_development_dependencies
-    pytest_output = run([f'{env_bin}pytest'], project_dir)
+    project_dir, bin_dir = baked_with_development_dependencies
+    pytest_output = run([f'{bin_dir}pytest'], project_dir)
     assert pytest_output.returncode == 0
     assert '== 3 passed in' in pytest_output.stdout
     assert (project_dir / 'coverage.xml').exists()
@@ -49,7 +55,7 @@ def test_pytest(baked_with_development_dependencies):
 
 
 def test_subpackage(baked_with_development_dependencies):
-    project_dir, env_bin = baked_with_development_dependencies
+    project_dir, bin_dir = baked_with_development_dependencies
     subpackage = (project_dir / 'my_python_package' / 'mysub')
     subpackage.mkdir()
     (subpackage / '__init__.py').write_text('FOO = "bar"', encoding="utf-8")
@@ -58,15 +64,16 @@ def test_subpackage(baked_with_development_dependencies):
     subsubpackage.mkdir()
     (subsubpackage / '__init__.py').write_text('FOO = "bar"', encoding="utf-8")
 
-    build_output = run([f'{env_bin}python', 'setup.py', 'build'], project_dir)
+    build_output = run([f'{bin_dir}python', 'setup.py', 'build'], project_dir)
     assert build_output.returncode == 0
     assert (project_dir / 'build' / 'lib' / 'my_python_package' / 'mysub' / '__init__.py').exists()
     assert (project_dir / 'build' / 'lib' / 'my_python_package' / 'mysub' / 'mysub2' / '__init__.py').exists()
 
 
 def test_generate_api_docs(baked_with_development_dependencies):
-    project_dir, env_bin = baked_with_development_dependencies
+    project_dir, bin_dir = baked_with_development_dependencies
 
-    build_output = run([f'{env_bin}sphinx-build', '-b', 'html', 'docs', 'docs/_build/html'], project_dir)
+    build_output = run([f'{bin_dir}sphinx-build', '-b', 'html', 'docs', 'docs/_build/html'], project_dir)
     assert build_output.returncode == 0
+    assert 'build succeeded' in build_output.stdout
     assert (project_dir / 'docs' / '_build' / 'html' / 'index.html').exists()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -34,13 +34,15 @@ def baked_with_development_dependencies(cookies):
         # Creating virtualenv does not work on Windows CI,
         # falling back to using current Python
         bin_dir = str(Path(executable).parent) + '\\'
+        print(bin_dir)
+        print(list(bin_dir.iterdir()))
     else:
         env_output = run(['python3', '-m', 'venv', 'env'], result.project)
         assert env_output.returncode == 0
         bin_dir = 'env/Scripts/' if platform.startswith("win") else 'env/bin/'
-    latest_pip_output = run([f'{bin_dir}pip3', 'install', '--upgrade', 'pip', 'setuptools'], result.project)
+    latest_pip_output = run([f'{bin_dir}pip', 'install', '--upgrade', 'pip', 'setuptools'], result.project)
     assert latest_pip_output.returncode == 0
-    pip_output = run([f'{bin_dir}pip3', 'install', '--editable', '.[dev]'], result.project)
+    pip_output = run([f'{bin_dir}pip', 'install', '--editable', '.[dev]'], result.project)
     assert pip_output.returncode == 0
     return result.project, bin_dir
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -15,16 +15,15 @@ def test_project_folder(cookies):
     assert project.project.isdir()
 
 
-def run(args: Sequence[str], dirpath: os.PathLike, env_bin=None) -> subprocess.CompletedProcess:
-    env = os.environ.copy()
-    if env_bin:
-        env['PATH'] = os.getcwd() + env_bin + ':' + os.environ.get('PATH')
-    return subprocess.run(args=args,
+def run(args: Sequence[str], dirpath: os.PathLike) -> subprocess.CompletedProcess:
+    completed_process = subprocess.run(args=args,
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE,
                           cwd=dirpath,
-                          env=env,
                           encoding="utf-8")
+    print(completed_process.stdout)
+    print(completed_process.stderr)
+    return completed_process
 
 
 @pytest.fixture
@@ -33,16 +32,16 @@ def baked_with_development_dependencies(cookies):
     env_output = run(['python3', '-m', 'venv', 'env'], result.project)
     assert env_output.returncode == 0
     env_bin = 'env/Scripts/' if platform.startswith("win") else 'env/bin/'
-    latest_pip_output = run(['pip3', 'install', '--upgrade', 'pip', 'setuptools'], result.project, env_bin)
+    latest_pip_output = run([f'{env_bin}pip3', 'install', '--upgrade', 'pip', 'setuptools'], result.project)
     assert latest_pip_output.returncode == 0
-    pip_output = run(['pip3', 'install', '--editable', '.[dev]'], result.project, env_bin)
+    pip_output = run([f'{env_bin}pip3', 'install', '--editable', '.[dev]'], result.project)
     assert pip_output.returncode == 0
     return result.project, env_bin
 
 
 def test_pytest(baked_with_development_dependencies):
     project_dir, env_bin = baked_with_development_dependencies
-    pytest_output = run(['pytest'], project_dir, env_bin)
+    pytest_output = run([f'{env_bin}pytest'], project_dir)
     assert pytest_output.returncode == 0
     assert '== 3 passed in' in pytest_output.stdout
     assert (project_dir / 'coverage.xml').exists()
@@ -59,7 +58,7 @@ def test_subpackage(baked_with_development_dependencies):
     subsubpackage.mkdir()
     (subsubpackage / '__init__.py').write_text('FOO = "bar"', encoding="utf-8")
 
-    build_output = run([f'python3', 'setup.py', 'build'], project_dir, env_bin)
+    build_output = run([f'{env_bin}python', 'setup.py', 'build'], project_dir)
     assert build_output.returncode == 0
     assert (project_dir / 'build' / 'lib' / 'my_python_package' / 'mysub' / '__init__.py').exists()
     assert (project_dir / 'build' / 'lib' / 'my_python_package' / 'mysub' / 'mysub2' / '__init__.py').exists()
@@ -68,7 +67,6 @@ def test_subpackage(baked_with_development_dependencies):
 def test_generate_api_docs(baked_with_development_dependencies):
     project_dir, env_bin = baked_with_development_dependencies
 
-    docs_dir = project_dir / 'docs'
-    build_output = run([f'make', 'html'], docs_dir, env_bin)
+    build_output = run([f'{env_bin}sphinx-build', '-b', 'html', 'docs', 'docs/_build/html'], project_dir)
     assert build_output.returncode == 0
-    assert (docs_dir / '_build' / 'html' / 'index.html').exists()
+    assert (project_dir / 'docs' / '_build' / 'html' / 'index.html').exists()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -33,11 +33,9 @@ def baked_with_development_dependencies(cookies):
     result = cookies.bake()
     if platform.startswith("win") and os.environ.get('CI', False):
         # Creating virtualenv does not work on Windows CI,
-        # falling back to using current Python
+        # falling back to using current pip3 dir
         pip = Path(which('pip3'))
         bin_dir = str(pip.parent) + '\\'
-        print(bin_dir)
-        print(list(Path(bin_dir).iterdir()))
     else:
         env_output = run(['python3', '-m', 'venv', 'env'], result.project)
         assert env_output.returncode == 0
@@ -68,6 +66,9 @@ def test_subpackage(baked_with_development_dependencies):
     subsubpackage.mkdir()
     (subsubpackage / '__init__.py').write_text('FOO = "bar"', encoding="utf-8")
 
+    if platform.startswith("win") and os.environ.get('CI', False):
+        # On Windows CI python and pip executable are in different paths
+        bin_dir = ''
     build_output = run([f'{bin_dir}python', 'setup.py', 'build'], project_dir)
     assert build_output.returncode == 0
     assert (project_dir / 'build' / 'lib' / 'my_python_package' / 'mysub' / '__init__.py').exists()


### PR DESCRIPTION
Instead of `make html` using `sphinx-build ...` for better cross-platform compatibility.

Also got tests to work on Windows CI (refs #223). It also still works on my laptop:

```
PS C:\Users\stefanv\git\NLeSC\python-template> .\env\Scripts\pytest.exe -v
==================================================== test session starts ====================================================
platform win32 -- Python 3.9.4, pytest-4.6.11, py-1.10.0, pluggy-0.13.1 -- c:\users\stefanv\git\nlesc\python-template\env\scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\stefanv\git\NLeSC\python-template, inifile: setup.cfg, testpaths: tests
plugins: cookies-0.5.1, cov-2.11.1
collected 8 items

tests/test_project.py::test_project_folder PASSED                                                                      [ 12%]
tests/test_project.py::test_pytest PASSED                                                                              [ 25%]
tests/test_project.py::test_subpackage PASSED                                                                          [ 37%]
tests/test_project.py::test_generate_api_docs PASSED                                                                   [ 50%]
```

Refs #213