### PR TITLE
remove double CI build triggers

### DIFF
--- a/{{cookiecutter.directory_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Python package
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
 

--- a/{{cookiecutter.directory_name}}/.github/workflows/cffconvert.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/cffconvert.yml
@@ -1,6 +1,12 @@
 name: cffconvert
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
 

--- a/{{cookiecutter.directory_name}}/.github/workflows/markdown-link-check.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/markdown-link-check.yml
@@ -1,6 +1,12 @@
 name: markdown-link-check
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
 

--- a/{{cookiecutter.directory_name}}/.github/workflows/sonarcloud.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/sonarcloud.yml
@@ -2,8 +2,12 @@ name: sonarcloud
 
 on:
   push:
+    branches:
+    - main
   pull_request:
     types: [opened, synchronize, reopened]
+    branches:
+    - main
 
 jobs:
 


### PR DESCRIPTION
With `on: [push, pull_request]`, GitHub Actions will trigger CI jobs twice (when you are branching in the repo itself): once for pushing to the PR branch and once for the PR itself. This is wasteful of resources and also makes the overview unnecessarily cluttered. This PR triggers only on direct pushes to main and on PRs to main. This means that it won't trigger anymore on pushes to other branches, but this can easily be "reactivated" by creating a (draft) PR from your other branch.