### PR TITLE
Fix markdown-link-check errors

### DIFF
--- a/.mlc-config.json
+++ b/.mlc-config.json
@@ -15,6 +15,9 @@
         },
         {
           "pattern": "^.github/workflows/sonarcloud.yml$"
+        },
+        {
+          "pattern": "^https://readthedocs.org/dashboard/import.*"
         }
     ],
     "replacementPatterns": [

--- a/.mlc-config.json
+++ b/.mlc-config.json
@@ -22,5 +22,6 @@
     ],
     "replacementPatterns": [
     ],
+    "retryOn429": true,
     "timeout": "20s"
 }

--- a/{{cookiecutter.directory_name}}/.mlc-config.json
+++ b/{{cookiecutter.directory_name}}/.mlc-config.json
@@ -18,6 +18,9 @@
         },
         {
           "pattern": "^https://bestpractices.coreinfrastructure.org/projects/<replace-with-created-project-identifier>"
+        },
+        {
+          "pattern": "^https://readthedocs.org/dashboard/import.*"
         }
     ],
     "replacementPatterns": [

--- a/{{cookiecutter.directory_name}}/.mlc-config.json
+++ b/{{cookiecutter.directory_name}}/.mlc-config.json
@@ -25,5 +25,6 @@
     ],
     "replacementPatterns": [
     ],
+    "retryOn429": true,
     "timeout": "20s"
 }

--- a/{{cookiecutter.directory_name}}/project_setup.md
+++ b/{{cookiecutter.directory_name}}/project_setup.md
@@ -53,7 +53,7 @@ help you decide which tool to use for packaging.
 
 - Documentation should be put in the [`docs/`](docs/) directory. The contents have been generated using `sphinx-quickstart` (Sphinx version 1.6.5).
 - We recommend writing the documentation using Restructured Text (reST) and Google style docstrings.
-  - [Restructured Text (reST) and Sphinx CheatSheet](http://openalea.gforge.inria.fr/doc/openalea/doc/_build/html/source/sphinx/rest_syntax.html)
+  - [Restructured Text (reST) and Sphinx CheatSheet](https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html)
   - [Google style docstring examples](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
 - The documentation is set up with the ReadTheDocs Sphinx theme.
   - Check out its [configuration options](https://sphinx-rtd-theme.readthedocs.io/en/latest/).


### PR DESCRIPTION
Fix three errors with markdown-link-check:
- readthedocs.org/dashboard/import is not accessible;
- gforge.inria.fr is not accessible (and the tutorial has been updated in the new link);
- (#298) failure due to too many requests.