### PR TITLE
Update cffconvert.yml to version 2.0.0

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -1,15 +1,19 @@
 name: cffconvert
 
-on: push
+on:
+  push:
+    paths:
+      - CITATION.cff
 
 jobs:
-
-  cffconvert:
-    name: Verify citation metadata consistency
+  validate:
+    name: "validate"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        name: Check out a copy of the repository
+      - name: Check out a copy of the repository
+        uses: actions/checkout@v2
 
-      - uses: citation-file-format/cffconvert-github-action@main
-        name: Check whether the citation metadata from CITATION.cff is equivalent to that in .zenodo.json
+      - name: Check whether the citation metadata from CITATION.cff is valid
+        uses: citation-file-format/cffconvert-github-action@2.0.0
+        with:
+          args: "--validate"


### PR DESCRIPTION
Hello!

This PR updates `cffconvert-github-action` to 2.0.0.
In the new version, the `cffconvert-github-action` does not compare against Zenodo anymore, because Zenodo is using CITATION.cff directly now (see [this twitter post](https://twitter.com/zenodo_org/status/1420357001490706442)).

BTW it's perfectly fine if you don't feel like accepting this Pull Request for whatever reason -- we just thought it might be helpful is all.

We found your repository using a partially automated workflow; if you have any questions about that, feel free to create an issue over at https://github.com/cffbots/filtering/issues/

On behalf of the cffbots team,
@abelsiqueira / @fdiblen / @jspaaks