### PR TITLE
Add tox and change coverage configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
 
 [options.extras_require]
 dev =
+    coverage [toml]
     pytest<5.0.0,>=3.3.0
     pytest-cookies
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -69,6 +69,15 @@ def test_pytest(baked_with_development_dependencies, project_env_bin_dir):
     assert (project_dir / 'htmlcov' / 'index.html').exists()
 
 
+def test_tox(baked_with_development_dependencies, project_env_bin_dir):
+    project_dir = baked_with_development_dependencies
+    bin_dir = project_env_bin_dir
+    result = run([f'{bin_dir}tox'], project_dir)
+    assert result.returncode == 0
+    assert '== 3 passed in' in result.stdout
+    assert (project_dir / '.tox' / 'dist' / 'my_python_package-0.1.0.zip').exists()
+
+
 def test_subpackage(baked_with_development_dependencies, project_env_bin_dir):
     """Test if subpackages end up in sdist and bdist_wheel distributions"""
     project_dir = baked_with_development_dependencies

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -65,8 +65,15 @@ def test_pytest(baked_with_development_dependencies, project_env_bin_dir):
     result = run([f'{bin_dir}pytest'], project_dir)
     assert result.returncode == 0
     assert '== 3 passed in' in result.stdout
-    assert (project_dir / 'coverage.xml').exists()
-    assert (project_dir / 'htmlcov' / 'index.html').exists()
+
+
+def test_coverage(baked_with_development_dependencies, project_env_bin_dir):
+    project_dir = baked_with_development_dependencies
+    bin_dir = project_env_bin_dir
+    result = run([f'{bin_dir}coverage', 'run', '-m', 'pytest'], project_dir)
+    assert result.returncode == 0
+    assert '== 3 passed in' in result.stdout
+    assert (project_dir / '.coverage').exists()
 
 
 def test_tox(baked_with_development_dependencies, project_env_bin_dir):

--- a/{{cookiecutter.directory_name}}/README.dev.md
+++ b/{{cookiecutter.directory_name}}/README.dev.md
@@ -25,11 +25,40 @@ Afterwards check that the install directory is present in the `PATH` environment
 
 ## Running the tests
 
-Running the tests requires an activated virtual environment with the development tools installed.
+There are two ways to run tests.
+
+The first way requires an activated virtual environment with the development tools installed:
 
 ```shell
 pytest -v
 ```
+
+The second is to use `tox`, which can be installed separately (e.g. with `pip install tox`), i.e. not necessarily inside the virtual environment you use for installing `{{ cookiecutter.package_name }}`, but then builds the necessary virtual environments itself by simply running:
+
+```shell
+tox
+```
+
+Testing with `tox` allows for keeping the testing environment separate from your development environment.
+The development environment will typically accumulate (old) packages during development that interfere with testing; this problem is avoided by testing with `tox`.
+
+### Test coverage
+
+In addition to just running the tests to see if they pass, they can be used for coverage statistics, i.e. to determine how much of the package's code is actually executed during tests.
+In an activated virtual environment with the development tools installed, inside the package directory, run:
+
+```shell
+coverage run
+```
+
+This runs tests and stores the result in a `.coverage` file.
+To see the results on the command line, run
+
+```shell
+coverage report
+```
+
+`coverage` can also generate output in HTML and other formats; see `coverage help` for more information.
 
 ## Running linters locally
 

--- a/{{cookiecutter.directory_name}}/project_setup.md
+++ b/{{cookiecutter.directory_name}}/project_setup.md
@@ -42,7 +42,7 @@ help you decide which tool to use for packaging.
 - The `tests` folder contains:
   - Example tests that you should replace with your own meaningful tests (file: `test_my_module.py`)
 - The testing framework used is [PyTest](https://pytest.org)
-  - [PyTest introduction](http://pythontesting.net/framework/pytest/pytest-introduction/)
+  - [PyTest introduction](https://pythontest.com/pytest-book/)
   - PyTest is listed as a development dependency
   - This is configured in `setup.cfg`
 - The project uses [GitHub action workflows](https://docs.github.com/en/actions) to automatically run tests on GitHub infrastructure against multiple Python versions

--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -1,3 +1,21 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+branch = true
+source = ["{{ cookiecutter.package_name }}"]
+command_line = "-m pytest"
+
+[tool.tox]
+legacy_tox_ini = """
+[tox]
+envlist = py37,py38,py39
+skip_missing_interpreters = true
+[testenv]
+commands = pytest
+extras = dev
+"""

--- a/{{cookiecutter.directory_name}}/setup.cfg
+++ b/{{cookiecutter.directory_name}}/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
 [options.extras_require]
 dev =
     bump2version
+    coverage [toml]
     prospector[with_pyroma]
     isort
     pytest
@@ -55,16 +56,13 @@ dev =
     sphinx
     sphinx_rtd_theme
     sphinx-autoapi
+    tox
 publishing =
     twine
     wheel
 
 [options.packages.find]
 include = {{ cookiecutter.package_name }}, {{ cookiecutter.package_name }}.*
-
-[coverage:run]
-branch = True
-source = {{ cookiecutter.package_name }}
 
 [isort]
 lines_after_imports = 2
@@ -73,9 +71,3 @@ no_lines_before = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 known_first_party = {{ cookiecutter.package_name }}
 src_paths = {{ cookiecutter.package_name }},tests
 line_length = 120
-
-[tool:pytest]
-testpaths = tests
-# Note that visual debugger in some editors like pycharm gets confused by coverage calculation.
-# As a workaround, configure the test configuration in pycharm et al with a --no-cov argument
-addopts = --cov --cov-report xml --cov-report term --cov-report html


### PR DESCRIPTION
This PR changes two things:

1. It adds `tox` support, which provides a fix for #38 and is just generally nice to have (I personally always add it).
2. It takes out the coverage flags from the default pytest settings. The coverage flags were breaking IDE test discovery. Instead, coverage can just be run separately with `coverage` or by supplying the flags manually, like is being done in the `sonarcloud` Actions workflow.

_Edit:_ also updated a broken link.