### PR TITLE
add separate documentation GA workflow

### DIFF
--- a/{{cookiecutter.directory_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/build.yml
@@ -37,9 +37,6 @@ jobs:
         run: pytest -v
       - name: Verify that we can build the package
         run: python3 setup.py sdist bdist_wheel
-      - name: Build documentation
-        run: make coverage doctest html
-        working-directory: docs
 
   lint:
     name: Linting build

--- a/{{cookiecutter.directory_name}}/.github/workflows/documentation.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/documentation.yml
@@ -1,0 +1,36 @@
+name: documentation
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  build-documentation:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Python info
+        shell: bash -l {0}
+        run: |
+          which python3
+          python3 --version
+      - name: Upgrade pip and install dependencies
+        run: |
+          python3 -m pip install --upgrade pip setuptools
+          python3 -m pip install .[dev,publishing]
+      - name: Install pandoc using apt
+        run: sudo apt install pandoc        
+      - name: Build documentation
+        run: make coverage doctest html
+        working-directory: docs


### PR DESCRIPTION
Removes building the docs from the build package workflow and adds a separate workflow for this. This way, failing workflow messages are immediately more informative.