### PR TITLE
add myst_parser to allow markdown files in toclist in docs

### DIFF
--- a/{{cookiecutter.directory_name}}/docs/conf.py
+++ b/{{cookiecutter.directory_name}}/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "autoapi.extension",
+    "myst_parser",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/{{cookiecutter.directory_name}}/setup.cfg
+++ b/{{cookiecutter.directory_name}}/setup.cfg
@@ -57,6 +57,7 @@ dev =
     sphinx_rtd_theme
     sphinx-autoapi
     tox
+    myst_parser
 publishing =
     twine
     wheel


### PR DESCRIPTION
Adds the sphinx plugin `myst_parser`. This allows you to add Markdown files directly to the `toclist` in `index.rst`. That way an unnecessary manual transformation step from Markdown to RST is avoided.