### PR TITLE
add .tox to .gitignore

### DIFF
--- a/{{cookiecutter.directory_name}}/.gitignore
+++ b/{{cookiecutter.directory_name}}/.gitignore
@@ -12,6 +12,7 @@ htmlcov
 .coverage
 coverage.xml
 .pytest_cache
+.tox
 
 docs/_build
 


### PR DESCRIPTION
In #311, I forgot to add the .tox directory to .gitignore. Tox stores environments and logs and such there.