### PR TITLE
feat(workflow): add workflow to handle stale issues and PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ my-python-project/
 │       ├── lint.yml
 │       ├── markdown-link-check.yml
 │       ├── next_steps.yml
-│       └── sonarcloud.yml
+│       ├── sonarcloud.yml
+│       └── stale_issue_pr.yml
 ├── .gitignore
 ├── LICENSE
 ├── MANIFEST.in

--- a/{{cookiecutter.directory_name}}/.github/workflows/stale_issue_pr.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/stale_issue_pr.yml
@@ -1,0 +1,24 @@
+name: Close inactive issues and pull requests
+on:
+  schedule:
+    - cron: "14 3 * * 1,3,5" # check at 03:14 on Monday, Wednesday, and Friday
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5.0.0
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 7
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity. Remove `stale` label or comment or this will be closed in 7 days."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          exempt-issue-labels: 'blocked'
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+          stale-pr-message: "This PR is stale because it has been open for 14 days with no activity. Remove `stale`` label or comment or this will be closed in 7 days."
+          close-pr-message: "This PR was closed because it has been inactive for 7 days since being marked as stale."
+          exempt-pr-labels: 'blocked'


### PR DESCRIPTION
**Description**

<!-- Description of PR -->
Related to issue #324 .
Add gh action to check and close stale issues and PRs. 

With current setting, the action runs at midnight of every Mon., Wed. and Friday.
If an issue has no no activity for 30 days after creating, it'll be labeled as `stale`; if no activity for 7 days after marking `stale`, it'll be closed. 
For a PR, it's 14 days for labelling `stale` and 7 days for closing it.

It uses this gh action https://github.com/actions/stale

**Instructions to review the pull request**

<!-- remove what doesn't apply or add more if needed -->
Create a `python-template-test` repo on GitHub (will be overwritten if existing)
```
cd $(mktemp -d --tmpdir py-tmpl-XXXXXX)
cookiecutter -c <pr-branch> https://github.com/<pr-user>/python-template
# Fill with python-template-test info
cd python-template-test
git init
git add --all
git commit -m "First commit"
git remote add origin https://github.com/<you>/python-template-test
git push -u origin main -f
python -m venv env
source env/bin/activate
python -m pip install --upgrade pip setuptools
python -m pip install '.[dev,publishing]'
```
