### PR TITLE
Fixes authentication confusion

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -5,6 +5,6 @@
     "package_name": cookiecutter.package_name.lower().replace(" ", "_").replace("-", "_"),
     "directory_name": cookiecutter.directory_name.lower().replace(" ", "-"),
     "full_name": cookiecutter.full_name.replace('\"', '\\\"'),
-    "repository": "https://github.com/" + cookiecutter.github_organization + "/" + cookiecutter.directory_name.lower().replace(" ", "-"),
+    "repository": "git@github.com:" + cookiecutter.github_organization + "/" + cookiecutter.directory_name.lower().replace(" ", "-"),
     "package_short_description": cookiecutter.package_short_description.replace('\"', '\\\"')
 }) }}

--- a/{{cookiecutter.directory_name}}/next_steps.md
+++ b/{{cookiecutter.directory_name}}/next_steps.md
@@ -6,6 +6,13 @@ Once your Python package is created, put it under [version
 control](https://guide.esciencecenter.nl/#/best_practices/version_control) using
 [git](https://git-scm.com/) and [GitHub](https://github.com/).
 
+Note that the next step assumes you have setup your connection to GitHub via SSH,
+see [Connecting to GitHub with SSH](https://docs.github.com/en/github-ae@latest/authentication/connecting-to-github-with-ssh).
+
+Alternatively, you can also use a personal access token, see
+[Creating a personal access token](https://docs.github.com/en/github-ae@latest/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).  If you choose this option, below you will have to replace
+`git@github.com:` by `https://github.com/`.
+
 ```shell
 cd {{ cookiecutter.directory_name }}
 git init


### PR DESCRIPTION
Sets the default authentication to ssh. The user is informed of this choice and provides information on how to use other forms of authentication.

**Description**
See above.

**Related issues**:
- 289: authentication confusion when doing git push in next_steps.md

**Instructions to review the pull request**

<!-- remove what doesn't apply or add more if needed -->
Create a `python-template-test` repo on GitHub (will be overwritten if existing)
```
cd $(mktemp -d --tmpdir py-tmpl-XXXXXX)
cookiecutter -c <pr-branch> https://github.com/<pr-user>/python-template
# Fill with python-template-test info
cd python-template-test
git init
git add --all
git commit -m "First commit"
git remote add origin https://github.com/<you>/python-template-test
git push -u origin main -f
python -m venv env
source env/bin/activate
python -m pip install --upgrade pip setuptools
python -m pip install '.[dev,publishing]'
```
