### PR TITLE
Update python versions in CI matrix: -3.6, +3.10, +3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ version = 0.4.0
 [options]
 zip_safe = False
 include_package_data = True
-python_requires >= 3.7
+python_requires = >=3.7
 packages =
 install_requires =
     cookiecutter==1.7.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,11 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Natural Language :: English
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 description = Cookiecutter template to initialize Python projects in accordance with Netherlands eScience Center best practices
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -29,6 +30,7 @@ version = 0.4.0
 [options]
 zip_safe = False
 include_package_data = True
+python_requires >= 3.7
 packages =
 install_requires =
     cookiecutter==1.7.2
@@ -42,7 +44,7 @@ install_requires =
 [options.extras_require]
 dev =
     coverage [toml]
-    pytest<5.0.0,>=3.3.0
+    pytest
     pytest-cookies
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -82,7 +82,8 @@ def test_tox(baked_with_development_dependencies, project_env_bin_dir):
     result = run([f'{bin_dir}tox'], project_dir)
     assert result.returncode == 0
     assert '== 3 passed in' in result.stdout
-    assert (project_dir / '.tox' / 'dist' / 'my_python_package-0.1.0.zip').exists()
+    # assert (project_dir / '.tox' / 'dist' / 'my_python_package-0.1.0.zip').exists()
+    assert (project_dir / '.tox' / '.pkg'  / 'dist'/ 'my_python_package-0.1.0.tar.gz').exists()
 
 
 def test_subpackage(baked_with_development_dependencies, project_env_bin_dir):

--- a/{{cookiecutter.directory_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ '{{ ' -}} matrix.python-version }}

--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -13,7 +13,7 @@ command_line = "-m pytest"
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py37,py38,py39
+envlist = py37,py38,py39,py310,py311
 skip_missing_interpreters = true
 [testenv]
 commands = pytest

--- a/{{cookiecutter.directory_name}}/setup.cfg
+++ b/{{cookiecutter.directory_name}}/setup.cfg
@@ -18,10 +18,11 @@ classifiers =
     }[cookiecutter.license] }}
     Natural Language :: English
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 description = {{ cookiecutter.package_short_description }}
 keywords =
     {{ cookiecutter.keyword1 }}
@@ -36,6 +37,7 @@ version = {{ cookiecutter.version }}
 
 [options]
 zip_safe = False
+python_requires = >=3.7
 include_package_data = True
 packages = find:
 install_requires =


### PR DESCRIPTION
**Description**
Adds python 3.10 and 3.11 to the test matrix.

**Related issues**:
- #312 


