### PR TITLE
run CI only on push/PR to main

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,6 +1,12 @@
 name: markdown-link-check
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,12 @@ name: tests
 
 on:
   push:
+    branches:
+    - main
   pull_request:
     types: [opened, synchronize, reopened]
-
+    branches:
+    - main
 jobs:
 
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
     - main
   pull_request:
-    types: [opened, synchronize, reopened]
     branches:
     - main
 jobs:


### PR DESCRIPTION
**Description**
As noticed by @BSchilperoort, the CI currently runs twice when new commits are pushed to a PR. This can be limited to only run on the `main` branch itself or PRs to `main`.
