### PR TITLE
add read/write permissions to allow issue creation

### DIFF
--- a/{{cookiecutter.directory_name}}/.github/workflows/next_steps.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/next_steps.yml
@@ -1,6 +1,6 @@
 on: [push]
 permissions:
-  contents: read
+  contents: write
   issues: write
 name: Create issues for next steps
 jobs:

--- a/{{cookiecutter.directory_name}}/.github/workflows/next_steps.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/next_steps.yml
@@ -1,4 +1,7 @@
 on: [push]
+permissions:
+  contents: read
+  issues: write
 name: Create issues for next steps
 jobs:
   next_steps:


### PR DESCRIPTION
Adding permissions to the workflow allows issues to be created.

See the first few lines of the action usage at https://github.com/JasonEtco/create-an-issue

I made this change [in my own project](https://github.com/elpaco-escience/scikit-talk/pull/20/commits/9479bfde92445891b670815befd358deca2c39ec), which [fixed permissions to create issues](https://github.com/elpaco-escience/scikit-talk/actions/runs/4636907034/jobs/8205268492), but still failed when deleting them.

This is fixed when also giving write permissions for content; see [this action run](https://github.com/bvreede/my-python-project/actions/runs/4639367682).

Closes #332 
