### PR TITLE
Remove more python3/pip3 commands from docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,8 @@ The sections below outline the steps in each case.
 1. (**important**) announce your plan to the rest of the community _before you start working_. This announcement should be in the form of a (new) issue;
 1. (**important**) wait until some kind of consensus is reached about your idea being a good idea;
 1. if needed, fork the repository to your own Github profile and create your own feature branch off of the latest main commit. While working on your feature branch, make sure to stay up to date with the main branch by pulling in changes, possibly from the 'upstream' repository (follow the instructions [here](https://help.github.com/articles/configuring-a-remote-for-a-fork/) and [here](https://help.github.com/articles/syncing-a-fork/));
-1. Install dependencies with `pip3 install -r requirements.txt`;
-1. make sure the existing tests still work by running ``pytest``. If project tests fails use ``pytest --keep-baked-projects`` to keep generated project in /tmp/pytest-* and investigate;
+1. install dependencies (see the [development documentation](README.dev.md#create-a-virtual-environment));
+1. make sure the existing tests still work by running ``pytest``. If project tests fail use ``pytest --keep-baked-projects`` to keep generated project files in `/tmp/pytest-*` and investigate;
 1. add your own tests (if necessary);
 1. update or expand the documentation;
 1. push your feature branch to (your fork of) the Python Template repository on GitHub;

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ We recommend installing `cookiecutter` in user space as per `cookiecutter`'s ins
 install `cookiecutter` for every new project.
 
 ```shell
-python3 -m pip install --user --upgrade cookiecutter
+python -m pip install --user --upgrade cookiecutter
 ```
 
 ### Step 2/3: Generate the files and directory structure

--- a/{{cookiecutter.directory_name}}/README.md
+++ b/{{cookiecutter.directory_name}}/README.md
@@ -33,7 +33,7 @@ To install {{ cookiecutter.package_name }} from GitHub repository, do:
 ```console
 git clone {{ cookiecutter.repository }}.git
 cd {{ cookiecutter.directory_name }}
-python3 -m pip install .
+python -m pip install .
 ```
 
 ## Documentation


### PR DESCRIPTION
A few remaining `python3`/`pip3` mentions are now replaced by `python` / removed. This should have been done in 9686cf7272f148c7692bd97107cad1c7dea4bad8.