### PR TITLE
Re-use baked project for all tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,4 @@ jobs:
         python -m pip install .[dev]
     - name: Run pytest
       run: |
-        python -m pytest -v
+        python -m pytest -v --durations=0

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -14,8 +14,8 @@ def test_project_folder(cookies):
 
     assert project.exit_code == 0
     assert project.exception is None
-    assert project.project.basename == 'my-python-project'
-    assert project.project.isdir()
+    assert project.project_path.name == 'my-python-project'
+    assert project.project_path.is_dir()
 
 
 def run(args: Sequence[str], dirpath: os.PathLike) -> subprocess.CompletedProcess:
@@ -47,9 +47,9 @@ def baked_with_development_dependencies(cookies_session, project_env_bin_dir):
     bin_dir = project_env_bin_dir
     latest_pip_output = run([f'{bin_dir}python', '-m', 'pip', 'install', '--upgrade', 'pip', 'setuptools'], result.project_path)
     assert latest_pip_output.returncode == 0
-    pip_output = run([f'{bin_dir}python', '-m', 'pip', 'install', '--editable', '.[dev]'], result.project)
+    pip_output = run([f'{bin_dir}python', '-m', 'pip', 'install', '--editable', '.[dev]'], result.project_path)
     assert pip_output.returncode == 0
-    return result.project
+    return result.project_path
 
 
 def test_pytest(baked_with_development_dependencies, project_env_bin_dir):


### PR DESCRIPTION
**Description**

<!-- Description of PR -->
Speed up the tests by re-using the baked project.

Also:
- replace the deprecated `.project` with `.project_path`
- fix the API docs test where the output has changed a bit
- use `--no-autodetect` when running prospector to avoid a warning about Django not being installed

Output of `pytest --durations=0` before (119 seconds):
```
============================================================================= slowest durations =============================================================================
10.56s setup    tests/test_project.py::test_bumpversion
10.56s setup    tests/test_project.py::test_tox
10.37s setup    tests/test_project.py::test_doctest_api_docs
10.36s setup    tests/test_project.py::test_coverage_api_docs
10.28s setup    tests/test_project.py::test_prospector
10.20s setup    tests/test_project.py::test_subpackage
10.19s setup    tests/test_project.py::test_isort_check
10.15s setup    tests/test_project.py::test_generate_api_docs
10.08s setup    tests/test_project.py::test_coverage
10.07s call     tests/test_project.py::test_tox
9.85s setup    tests/test_project.py::test_pytest
3.02s call     tests/test_project.py::test_prospector
0.72s call     tests/test_project.py::test_generate_api_docs
0.57s call     tests/test_project.py::test_coverage_api_docs
0.55s call     tests/test_project.py::test_doctest_api_docs
0.18s call     tests/test_project.py::test_coverage
0.12s call     tests/test_project.py::test_pytest
0.09s teardown tests/test_project.py::test_tox
0.09s call     tests/test_project.py::test_subpackage
0.08s call     tests/test_project.py::test_project_folder
0.08s call     tests/test_values.py::test_double_quotes_in_name_and_description
0.07s call     tests/test_project.py::test_isort_check
0.06s call     tests/test_values.py::test_dash_in_directory_name
0.06s call     tests/test_values.py::test_space_in_directory_name
0.06s call     tests/test_values.py::test_single_quotes_in_name_and_description
0.05s call     tests/test_project.py::test_bumpversion
```
and after (25 seconds):
```
9.81s setup    tests/test_project.py::test_pytest
9.26s call     tests/test_project.py::test_tox
3.50s call     tests/test_project.py::test_prospector
0.69s call     tests/test_project.py::test_generate_api_docs
0.55s call     tests/test_project.py::test_doctest_api_docs
0.54s call     tests/test_project.py::test_coverage_api_docs
0.21s call     tests/test_project.py::test_coverage
0.12s call     tests/test_project.py::test_pytest
0.10s call     tests/test_project.py::test_subpackage
0.08s call     tests/test_project.py::test_project_folder
0.07s call     tests/test_values.py::test_dash_in_directory_name
0.06s call     tests/test_project.py::test_isort_check
0.06s call     tests/test_values.py::test_double_quotes_in_name_and_description
0.06s call     tests/test_values.py::test_space_in_directory_name
0.06s call     tests/test_values.py::test_single_quotes_in_name_and_description
0.04s call     tests/test_project.py::test_bumpversion
```