### PR TITLE
Remove remaining setup.cfg references

### DIFF
--- a/{{cookiecutter.directory_name}}/.github/next_steps/05_linting.md
+++ b/{{cookiecutter.directory_name}}/.github/next_steps/05_linting.md
@@ -4,7 +4,7 @@ title: 'Next step: Linting'
 
 Your repository has a [workflow]({{ cookiecutter.repository_url }}/blob/main/.github/workflows/build.yml) which [lints](https://en.wikipedia.org/wiki/Lint_(software)) your code after every push and when creating a pull request.
 
-Linter workflow may fail if `description` or `keywords` field in [setup.cfg]({{ cookiecutter.repository_url }}/blob/main/setup.cfg) is empty. Please update these fields. To validate your changes run:
+Linter workflow may fail if `description` or `keywords` field in [pyproject.toml]({{ cookiecutter.repository_url }}/blob/main/pyproject.toml) is empty. Please update these fields. To validate your changes run:
 
 ```shell
 ruff .

--- a/{{cookiecutter.directory_name}}/project_setup.md
+++ b/{{cookiecutter.directory_name}}/project_setup.md
@@ -28,8 +28,8 @@ to use one or the other, as project requirements differ. For advice on what to u
 of the
 guide](https://guide.esciencecenter.nl/#/best_practices/language_guides/python?id=dependencies-and-package-management).
 
-- Runtime dependencies should be added to `setup.cfg` in the `install_requires` list under `[options]`.
-- Development dependencies should be added to `setup.cfg` in one of the lists under `[options.extras_require]`.
+- Runtime dependencies should be added to `pyproject.toml` in the `dependencies` list under `[project]`.
+- Development dependencies should be added to `pyproject.toml` in one of the lists under `[project.optional-dependencies]`.
 
 ## Packaging/One command install
 
@@ -45,7 +45,7 @@ help you decide which tool to use for packaging.
 - The testing framework used is [PyTest](https://pytest.org)
   - [PyTest introduction](https://pythontest.com/pytest-book/)
   - PyTest is listed as a development dependency
-  - This is configured in `setup.cfg`
+  - This is configured in `pyproject.toml`
 - The project uses [GitHub action workflows](https://docs.github.com/en/actions) to automatically run tests on GitHub infrastructure against multiple Python versions
   - Workflows can be found in [`.github/workflows`](.github/workflows/)
 - [Relevant section in the guide](https://guide.esciencecenter.nl/#/best_practices/language_guides/python?id=testing)


### PR DESCRIPTION
There is still one reference remaining in `.bumpversion.cfg`, but issue #362 should be resolved before we can effectively remove that one.

**Related issues**:
- closes #360 