### PR TITLE
add link to impact discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ list below:
 1. pycff: [https://github.com/citation-file-format/pycff](https://github.com/citation-file-format/pycff)
 1. spec2vec: [https://github.com/iomega/spec2vec](https://github.com/iomega/spec2vec)
 1. yatiml: [https://github.com/yatiml/yatiml](https://github.com/yatiml/yatiml)
-1. _... And many more. Make a PR to add your project here!_
+1. _... And many more (see [this discussion](https://github.com/NLeSC/python-template/issues/48)). Make a PR to add your project here, or simply ping us in an issue!_
 
 
 ## How to contribute


### PR DESCRIPTION
This way, we can close the issue (#48), but still have a convenient link to the discussion to revisit the list when necessary.

The process to update the list described there is given by @eriktks:

> Lists of repositories using this Python template on 13 April 2021 based on searching Github: https://github.com/search?p=2&q=nlesc+cookiecutter&type=Code (the search finds several other irrelevant pages). Lists expanded on 4 May 2021 with ten more repositories from among others https://github.com/search?p=6&q=%22Relevant+section+in+the+guide%22&type=Code