### PR TITLE
Bumpversion bug

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -182,7 +182,7 @@ def test_bumpversion(baked_with_development_dependencies, project_env_bin_dir):
     assert original_version in (project_dir / 'my_python_package' / '__init__.py').read_text('utf-8')
     assert original_version in (project_dir / 'docs' / 'conf.py').read_text('utf-8')
 
-    result = run([f'{bin_dir}bump-my-version', 'major'], project_dir)
+    result = run([f'{bin_dir}bump-my-version', 'bump', 'major'], project_dir)
     assert result.returncode == 0
     assert '' in result.stdout
     expected_version = '1.0.0'

--- a/{{cookiecutter.directory_name}}/README.dev.md
+++ b/{{cookiecutter.directory_name}}/README.dev.md
@@ -116,9 +116,9 @@ make doctest
 Bumping the version across all files is done with [bump-my-version](https://github.com/callowayproject/bump-my-version), e.g.
 
 ```shell
-bump-my-version major  # bumps from e.g. 0.3.2 to 1.0.0
-bump-my-version minor  # bumps from e.g. 0.3.2 to 0.4.0
-bump-my-version patch  # bumps from e.g. 0.3.2 to 0.3.3
+bump-my-version bump major  # bumps from e.g. 0.3.2 to 1.0.0
+bump-my-version bump minor  # bumps from e.g. 0.3.2 to 0.4.0
+bump-my-version bump patch  # bumps from e.g. 0.3.2 to 0.3.3
 ```
 
 ## Making a release


### PR DESCRIPTION
**Description**

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] This update is in line with what is recommended in the [Python chapter of the Guide](https://guide.esciencecenter.nl/#/best_practices/language_guides/python)


There has been a breaking change in bumpy-my-version. Instead of `bump-my-version major`, you need to do `bump-my-version bump major`, which I fixed in the tests and in the `README.dev.md` for the generated package.

See https://github.com/callowayproject/bump-my-version/blob/master/CHANGELOG.md#0190-2024-03-12


**Instructions to review the pull request**

<!-- remove what doesn't apply or add more if needed -->
Create a `python-template-test` repo on GitHub (will be overwritten if existing)
```
cd $(mktemp -d --tmpdir py-tmpl-XXXXXX)
cookiecutter -c bumpversion-bug https://github.com/f-hafner/python-template
# Fill with python-template-test info
cd python-template-test
git init
git add --all
git commit -m "First commit"
git remote add origin https://github.com/<you>/python-template-test
git push -u origin main -f
python -m venv env
source env/bin/activate
python -m pip install --upgrade pip setuptools
python -m pip install '.[dev,publishing]'
```
