### PR TITLE
Enable quiet mode for markdown link checker

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -17,4 +17,5 @@ jobs:
     - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
+        use-quiet-mode: 'yes'
         config-file: '.mlc-config.json'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Regenerated docs/conf.py with sphinx-quickstart v3.5.4 + enabled built-in extensions [#44](https://github.com/NLeSC/python-template/issues/44)
 * Generate api rst files with extension instead of custom function [#95](https://github.com/NLeSC/python-template/issues/95)
 * Change from bump2version (unmaintained) to bump-my-version.
+* Set markdown link checker to quiet mode: only report broken links [#262](https://github.com/NLeSC/python-template/issues/262)
 
 ### Removed
 

--- a/{{cookiecutter.directory_name}}/.github/workflows/markdown-link-check.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/markdown-link-check.yml
@@ -17,4 +17,5 @@ jobs:
     - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
+        use-quiet-mode: 'yes'
         config-file: '.mlc-config.json'


### PR DESCRIPTION
**Description**

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] This update is in line with what is recommended in the [Python chapter of the Guide](https://guide.esciencecenter.nl/#/best_practices/language_guides/python)

Enables the 'use-quiet-mode' setting in the markdown link checker to only show broken links

Fixes #262