### PR TITLE
Add extra optional-dependencies section for documentation requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Docstring for function
 * Intersphinx to documentation
 * Coverage and doctest commands for documentation [#97](https://github.com/NLeSC/python-template/issues/97)
+* Added new 'docs' section in extra dependencies [#317](https://github.com/NLeSC/python-template/issues/317)
 
 ### Changed
 

--- a/{{cookiecutter.directory_name}}/.readthedocs.yaml
+++ b/{{cookiecutter.directory_name}}/.readthedocs.yaml
@@ -4,4 +4,4 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - dev
+        - docs

--- a/{{cookiecutter.directory_name}}/README.dev.md
+++ b/{{cookiecutter.directory_name}}/README.dev.md
@@ -19,6 +19,8 @@ python -m pip install --upgrade pip setuptools
 python -m pip install --no-cache-dir --editable .
 # install development dependencies
 python -m pip install --no-cache-dir --editable .[dev]
+# install documentation dependencies only
+python -m pip install --no-cache-dir --editable .[docs]
 ```
 
 Afterwards check that the install directory is present in the `PATH` environment variable.

--- a/{{cookiecutter.directory_name}}/project_setup.md
+++ b/{{cookiecutter.directory_name}}/project_setup.md
@@ -29,7 +29,7 @@ of the
 guide](https://guide.esciencecenter.nl/#/best_practices/language_guides/python?id=dependencies-and-package-management).
 
 - Runtime dependencies should be added to `pyproject.toml` in the `dependencies` list under `[project]`.
-- Development dependencies should be added to `pyproject.toml` in one of the lists under `[project.optional-dependencies]`.
+- Development dependencies, such as for testing or documentation, should be added to `pyproject.toml` in one of the lists under `[project.optional-dependencies]`.
 
 ## Packaging/One command install
 

--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -56,6 +56,12 @@ dev = [
     "tox",
     "myst_parser",
 ]
+docs = [
+    "sphinx",
+    "sphinx_rtd_theme",
+    "sphinx-autoapi",
+    "myst_parser",
+]
 publishing = [
     "build",
     "twine",


### PR DESCRIPTION
**Description**

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] This update is in line with what is recommended in the [Python chapter of the Guide](https://guide.esciencecenter.nl/#/best_practices/language_guides/python)
- [x] All user facing changes have been added to CHANGELOG.md

Create a separate optional-dependencies section for documentation, and switched `.readthedocs.yaml` from 'dev' to 'docs'.

No documentation dependencies can be removed from 'dev', since we also have tests on the documentation generation.