### PR TITLE
Remove unused isort configuration

### DIFF
--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -75,14 +75,6 @@ branch = true
 source = ["src/{{ cookiecutter.package_name }}"]
 command_line = "-m pytest"
 
-[tool.isort]
-lines_after_imports = 2
-force_single_line = 1
-no_lines_before = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
-known_first_party = "{{ cookiecutter.package_name }}"
-src_paths = ["src/{{ cookiecutter.package_name }}", "tests"]
-line_length = 120
-
 [tool.tox]
 legacy_tox_ini = """
 [tox]


### PR DESCRIPTION
**Description**

- [x] I have read the [contribution guidelines](https://github.com/NLeSC/python-template/blob/main/CONTRIBUTING.md)
- [x] This update is in line with what is recommended in the [Python chapter of the Guide](https://guide.esciencecenter.nl/#/best_practices/language_guides/python)
- [x] All user facing changes have been added to CHANGELOG.md

Remove the configuration of isort, which is no longer used since #347.