### PR TITLE
378b ruff config update dbodor

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check whether the citation metadata from CITATION.cff is valid
         uses: citation-file-format/cffconvert-github-action@2.0.0

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check markdown links
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         config-file: '.mlc-config.json'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,9 @@ jobs:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Python info

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -167,7 +167,7 @@ def test_ruff_check(baked_with_development_dependencies, project_env_bin_dir):
     project_dir = baked_with_development_dependencies
     bin_dir = project_env_bin_dir
 
-    result = run([f'{bin_dir}ruff', '.'], project_dir)
+    result = run([f'{bin_dir}ruff', 'check', '--fix'], project_dir)
     assert result.returncode == 0
     assert '' in result.stdout
 

--- a/{{cookiecutter.directory_name}}/.githooks/pre-commit
+++ b/{{cookiecutter.directory_name}}/.githooks/pre-commit
@@ -6,7 +6,8 @@ echo "Script $0 triggered ..."
 echo "Starting ruff analysis..."
 
 # quietly run ruff
-ruff check . --fix
+ruff check --fix
+ruff format
 
 # use return code to abort commit if necessary
 if [ $? != "0" ]; then

--- a/{{cookiecutter.directory_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ '{{ ' -}} matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ '{{ ' -}} matrix.python-version }}
       - name: Python info
@@ -44,9 +44,9 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Python info

--- a/{{cookiecutter.directory_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/build.yml
@@ -59,4 +59,6 @@ jobs:
           python -m pip install --upgrade pip setuptools
           python -m pip install .[dev,publishing]
       - name: Check style against standards using ruff
-        run: ruff .
+        run: |
+          ruff check
+          ruff format --check

--- a/{{cookiecutter.directory_name}}/.github/workflows/cffconvert.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/cffconvert.yml
@@ -14,7 +14,7 @@ jobs:
     name: "cffconvert"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Check out a copy of the repository
 
       - name: Check whether the citation metadata from CITATION.cff is valid

--- a/{{cookiecutter.directory_name}}/.github/workflows/documentation.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/documentation.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Python info

--- a/{{cookiecutter.directory_name}}/.github/workflows/markdown-link-check.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/markdown-link-check.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check markdown links
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         config-file: '.mlc-config.json'

--- a/{{cookiecutter.directory_name}}/.github/workflows/next_steps.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/next_steps.yml
@@ -7,7 +7,7 @@ jobs:
   next_steps:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create Sonarcloud integration issue
         uses: JasonEtco/create-an-issue@v2
         env:

--- a/{{cookiecutter.directory_name}}/.github/workflows/sonarcloud.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/sonarcloud.yml
@@ -15,11 +15,11 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Python info

--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -120,22 +120,13 @@ select = [
 
 ]
 ignore = [
-    'D100',  # Missing module docstring
-    'D104',  # Missing public package docstring
-    # The following list excludes rules irrelevant to the Google style
-    'D203',
-    'D204',
-    'D213',
-    'D215',
-    'D400',
-    'D401',
-    'D404',
-    'D406',
-    'D407',
-    'D408',
-    'D409',
-    'D413',
+    # No docstrings required in the following cases
+    "D100", # Missing module docstring
+    "D104", # Missing public package docstring
+    "D105", # Missing docstring in magic method
+    "D107", # Missing docstring in `__init__`
 ]
+pydocstyle.convention = "google"
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["A", "B", "C", "D", "E", "F", "I"]

--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -115,6 +115,7 @@ ignore = [
     "ANN204", # Missing return type annotation for special (dunder) method
     "FBT",    # Using boolean function arguments
     "TD",     # TODOs
+    "FIX001", # Resolve FIXMEs
     "FIX002", # Resolve TODOs
     "B028",   # No explicit `stacklevel` keyword argument found in warning
     # No docstrings required in the following cases
@@ -139,14 +140,20 @@ extend-safe-fixes = [
     "B006",   # Mutable default argument
 ]
 
-[lint.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = [
     "S101",   # Use of `assert` detected
     "PT011",  # pytest-raises-too-broad
+    "ANN001", # Missing function argument type
     "ANN201", # Missing return type
     "D103",   # Missing function docstring
     "ANN401", # Function arguments annotated with too generic `Any` type
     "SLF001", # Private member access
+]
+"docs/conf.py" = [
+    "INP001", # Add __init__.py to implicit namespace package
+    "ERA001", # Commented-out code
+    "A001",   # Shadowing Python builtin name, specifically `copyright`
 ]
 
 [tool.ruff.lint.isort]

--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -104,22 +104,19 @@ line-length = 120
 output-format = "concise"
 
 [tool.ruff.lint]
-# Enable Pyflakes `E` and `F` codes by default.
-select = [
-    "F",  # Pyflakes
-    "E",  # pycodestyle (error)
-    "W",    # pycodestyle (warning)
-    # "C90",  # mccabe
-    "I",    # isort
-    "D",    # pydocstyle
-    # "PL",   # Pylint
-    # "PLC",  # Convention
-    # "PLE",  # Error
-    # "PLR",  # Refactor
-    # "PLW",  # Warning
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-]
+# Enable Pyflakes `E` and `F` codes by default.
+select = ["ALL"]
 ignore = [
+    "ANN101", # Missing type annotation for `self` in method
+    "ANN102", # Missing type annotation for `cls` in classmethod
+    "ANN204", # Missing return type annotation for special (dunder) method
+    "FBT",    # Using boolean function arguments
+    "TD",     # TODOs
+    "FIX002", # Resolve TODOs
+    "B028",   # No explicit `stacklevel` keyword argument found in warning
     # No docstrings required in the following cases
     "D100", # Missing module docstring
     "D104", # Missing public package docstring
@@ -129,11 +126,28 @@ ignore = [
 pydocstyle.convention = "google"
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "I"]
-unfixable = []
+fixable = ["ALL"]
+unfixable = ["F401"] # unused imports (should not disappear while editing)
+extend-safe-fixes = [
+    "D415",   # First line should end with a period, question mark, or exclamation point
+    "D300",   # Use triple double quotes `"""`
+    "D200",   # One-line docstring should fit on one line
+    "TCH",    # Format type checking only imports
+    "ISC001", # Implicitly concatenated strings on a single line
+    "EM",     # Exception message variables
+    "RUF013", # Implicit Optional
+    "B006",   # Mutable default argument
+]
 
-# Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+[lint.per-file-ignores]
+"tests/*" = [
+    "S101",   # Use of `assert` detected
+    "PT011",  # pytest-raises-too-broad
+    "ANN201", # Missing return type
+    "D103",   # Missing function docstring
+    "ANN401", # Function arguments annotated with too generic `Any` type
+    "SLF001", # Private member access
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["{{ cookiecutter.package_name }}"]

--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -100,33 +100,8 @@ extras = dev
 """
 
 [tool.ruff]
-exclude = [
-    ".bzr",
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".hg",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "venv",
-    ".venv",
-    "scripts",
-]
-
-target-version = "py39"
 line-length = 120
-
+output-format = "concise"
 
 [tool.ruff.lint]
 # Enable Pyflakes `E` and `F` codes by default.
@@ -166,12 +141,8 @@ ignore = [
 fixable = ["A", "B", "C", "D", "E", "F", "I"]
 unfixable = []
 
-per-file-ignores = {}
-
-
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-
 
 [tool.ruff.lint.isort]
 known-first-party = ["{{ cookiecutter.package_name }}"]

--- a/{{cookiecutter.directory_name}}/src/{{cookiecutter.package_name}}/my_module.py
+++ b/{{cookiecutter.directory_name}}/src/{{cookiecutter.package_name}}/my_module.py
@@ -2,7 +2,7 @@
 
 
 # FIXME: put actual code here
-def hello(name):
+def hello(name: str) -> str:
     """Say hello.
 
     Function docstring using Google docstring style.


### PR DESCRIPTION
Additional updates to ruff settings on top of #384.

Extra changes:
- also perform ruff formatting check in githook and linting workflow
- removed explicit excluded file types
  - and will be read from ruff defaults instead
- output format is defaulted to "concise"
  - this used to be the default, but it changed to "full" as per ruff 0.5 and it's very lengthy.
- use ruff docstring convention rather than explicitly setting which docstring rules to ignore
- Turned on (almost) all linting rules, instead of hand-picking the main ones.
  - This may be slightly contentious, but I find that in a new project it's quite manageable (if applied to an existing project, it may be overwhelming)
  - Some rules are suppressed, which are the ones I have found to be over the top. I realize that this decision is somewhat arbitrary, but still think it works.
- Updated actions/checkout and actions/setup-python to their newest versions
  - this is a bit of scope creep...