### PR TITLE
Rename template folder and files in preparation of migration to copier

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -42,16 +42,15 @@ def project_env_bin_dir(tmp_path_factory):
 
 
 @pytest.fixture(scope='session')
-def baked_with_development_dependencies(tmp_path_factory, project_env_bin_dir):
-    project = run_copy(src_path=str(here()), dst_path=str(tmp_path_factory.mktemp('projects')), defaults=True)
-    project_dir = project.dst_path
-
+def baked_with_development_dependencies(copie_session, project_env_bin_dir):
+    result = copie_session.copy()
+    assert result.exit_code == 0
     bin_dir = project_env_bin_dir
-    latest_pip_output = run([f'{bin_dir}python', '-m', 'pip', 'install', '--upgrade', 'pip', 'setuptools'], project_dir)
+    latest_pip_output = run([f'{bin_dir}python', '-m', 'pip', 'install', '--upgrade', 'pip', 'setuptools'], result.project_dir)
     assert latest_pip_output.returncode == 0
-    pip_output = run([f'{bin_dir}python', '-m', 'pip', 'install', '--editable', '.[dev]'], project_dir)
+    pip_output = run([f'{bin_dir}python', '-m', 'pip', 'install', '--editable', '.[dev]'], result.project_dir)
     assert pip_output.returncode == 0
-    return project_dir
+    return result.project_dir
 
 
 def test_pytest(baked_with_development_dependencies, project_env_bin_dir):


### PR DESCRIPTION
**Description**

- [x] I have read the [contribution guidelines](https://github.com/NLeSC/python-template/blob/main/CONTRIBUTING.md)
- [x] This update is in line with what is recommended in the [Python chapter of the Guide](https://guide.esciencecenter.nl/#/best_practices/language_guides/python)
- [x] All user facing changes have been added to CHANGELOG.md

`pytest-cookies` had a `cookies_session` fixture, but `pytest-copie` did not yet have an equivalent when first switching from cookiecutter to copier. Since this will be added _soon_$^\text{tm}$, we can go back to using a dedicated fixture rather than creating such a session scoped template instance ourselves

---

$^\text{tm}$ once included in `pytest-copie`, this PR will be marked as ready