### PR TITLE
Handle double quotes in name and description.

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -11,10 +11,6 @@ package_name:
 package_short_description:
   type: str
   default: Short description of package
-  validator: >-
-        {% if (package_short_description | regex_replace ('"', '\\\\"')|regex_replace ("'", "\\\\'")%}
-        package_short_description must not contain unescaped double or single quotes.
-        {% endif %}
 keyword1:
   type: str
   default: keyword1
@@ -42,10 +38,6 @@ full_name:
   type: str
   default: Jane Smith
   help: Enter your full name.
-  # validator: >-
-  #       {% if '"' in full_name %}
-  #       full_name must not contain unescaped double quotes. Use \\" for double quotes.
-  #       {% endif %}
 email:
   type: str
   default: yourname@esciencecenter.nl

--- a/template/CITATION.cff.jinja
+++ b/template/CITATION.cff.jinja
@@ -4,8 +4,8 @@ cff-version: "1.2.0"
 title: "{{ package_name }}"
 authors:
   -
-    family-names: {{ full_name.split(' ')[-1] }}
-    given-names: {{ full_name.split(' ')[0] }}
+    family-names: {{ full_name.replace('\"', '\\\"').split(' ')[-1] }}
+    given-names: {{ full_name.replace('\"', '\\\"').split(' ')[0] }}
     orcid: "https://orcid.org/0000-0000-0000-0000"
 date-released: 20??-MM-DD
 doi: <insert your DOI here>

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -22,7 +22,7 @@
 
 ## How to use {{ package_name }}
 
-{{ package_short_description }}
+{{ package_short_description|replace('\"', '\\\"') }}
 
 The project setup is documented in [project_setup.md](project_setup.md). Feel free to remove this document (and/or the link to this document) if you don't need it.
 

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 authors = [
-    { name = "{{ full_name }}", email = "{{ email }}" }
+    { name = "{{ full_name|replace('\"', '\\\"') }}", email = "{{ email }}" }
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -31,7 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = []
-description = "{{ package_short_description }}"
+description = "{{ package_short_description|replace('\"', '\\\"') }}"
 keywords = [
     "{{ keyword1 }}",
     "{{ keyword2 }}",

--- a/template/src/{{package_name}}/__init__.py.jinja
+++ b/template/src/{{package_name}}/__init__.py.jinja
@@ -3,6 +3,6 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__author__ = "{{ full_name }}"
+__author__ = "{{ full_name|replace('\"', '\\\"') }}"
 __email__ = "{{ email }}"
 __version__ = "{{ version }}"


### PR DESCRIPTION
**Description**

- [x] I have read the [contribution guidelines](https://github.com/NLeSC/python-template/blob/main/CONTRIBUTING.md)
- [x] This update is in line with what is recommended in the [Python chapter of the Guide](https://guide.esciencecenter.nl/#/best_practices/language_guides/python)
- [ ] All user facing changes have been added to CHANGELOG.md

<!-- Description of PR -->
This PR handles double quotes in `full_name` and `package_short_description' which was originally in cookiecutter hooks.  
```
    "full_name": cookiecutter.full_name.replace('\"', '\\\"'),
    "package_short_description": cookiecutter.package_short_description.replace('\"', '\\\"')
```


**Related issues**:
- fixes #407 
- fixes #406



