### PR TITLE
Update PR template test instructions to use copier

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@
 <!-- remove what doesn't apply or add more if needed -->
 Create a `python-template-test` repo on GitHub (will be overwritten if existing)
 ```
-# Create a temporary directory in /tmp, keep the XXXXXX in the directory name
+# Create a temporary directory by running the following command. Keep the XXXXXX in the directory name. 
 cd $(mktemp -d --tmpdir py-tmpl-XXXXXX)
 # Use --vcs-ref <pr-branch> to point to the branch to you want to test
 copier copy --vcs-ref <pr-branch> https://github.com/<pr-user>/python-template .

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,10 +16,9 @@
 <!-- remove what doesn't apply or add more if needed -->
 Create a `python-template-test` repo on GitHub (will be overwritten if existing)
 ```
-cd $(mktemp -d --tmpdir py-tmpl-XXXXXX)
-cookiecutter -c <pr-branch> https://github.com/<pr-user>/python-template
+copier copy --vcs-ref <pr-branch> https://github.com/<pr-user>/python-template py-tmpl-XXXXXX
 # Fill with python-template-test info
-cd python-template-test
+cd py-tmpl-XXXXXX
 git init
 git add --all
 git commit -m "First commit"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,14 +16,18 @@
 <!-- remove what doesn't apply or add more if needed -->
 Create a `python-template-test` repo on GitHub (will be overwritten if existing)
 ```
-copier copy --vcs-ref <pr-branch> https://github.com/<pr-user>/python-template py-tmpl-XXXXXX
+# Create a temporary directory in /tmp, keep the XXXXXX in the directory name
+cd $(mktemp -d --tmpdir py-tmpl-XXXXXX)
+# Use --vcs-ref <pr-branch> to point to the branch to you want to test
+copier copy --vcs-ref <pr-branch> https://github.com/<pr-user>/python-template .
 # Fill with python-template-test info
-cd py-tmpl-XXXXXX
+# Create a local git repo to push to GitHub to trigger CI actions
 git init
 git add --all
 git commit -m "First commit"
-git remote add origin https://github.com/<you>/python-template-test
+git remote add origin git@github.com:<you>/python-template-test.git
 git push -u origin main -f
+# Create a local environment to test your generated package locally
 python -m venv env
 source env/bin/activate
 python -m pip install --upgrade pip setuptools


### PR DESCRIPTION
Swap out the old `cookiecutter` CLI instructions with the new `copier` instructions, specifically the `copier copy` command pointing to the branch for the PR.

Fixes #417 


- [x] I have read the [contribution guidelines](https://github.com/NLeSC/python-template/blob/main/CONTRIBUTING.md)
- [x] This update is in line with what is recommended in the [Python chapter of the Guide](https://guide.esciencecenter.nl/#/best_practices/language_guides/python)
- [x] All user facing changes have been added to CHANGELOG.md