### PR TITLE
Remove final cookiecutter mentions

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
-NLeSC Cookiecutter template for Python
+NLeSC Copier template for Python
 Copyright 2021, Netherlands eScience Center

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
-description = Cookiecutter template to initialize Python projects in accordance with Netherlands eScience Center best practices
+description = Copier template to initialize Python projects in accordance with Netherlands eScience Center best practices
 long_description = file: README.md
 long_description_content_type = text/markdown
 name = Netherlands eScience Center Python Template


### PR DESCRIPTION
Cookiecutter was still mentioned in `setup.cfg` and `NOTICE`. All remaining mentions are historic ones in `CHANGELOG.md`