### PR TITLE
Fix ruff test

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -102,6 +102,7 @@ extras = dev
 [tool.ruff]
 line-length = 120
 output-format = "concise"
+extend-exclude = ["docs"]
 
 [tool.ruff.lint]
 # Allow unused variables when underscore-prefixed.
@@ -126,7 +127,15 @@ ignore = [
 ]
 pydocstyle.convention = "google"
 
-[tool.ruff.isort]
+[tool.ruff.lint.per-file-ignores]
+# Tests can ignore a few extra rules
+"tests/**.py" = [
+    "ANN201", # Missing return type annotation for public function
+    "PT011",  # Missing `match` parameter in `pytest.raises()`
+    "S101",   # Use of assert is detected
+]
+
+[tool.ruff.lint.isort]
 known-first-party = ["{{ package_name }}"]
 force-single-line = true
 no-lines-before = ["future","standard-library","third-party","first-party","local-folder"]

--- a/template/src/{{package_name}}/my_module.py.jinja
+++ b/template/src/{{package_name}}/my_module.py.jinja
@@ -25,5 +25,6 @@ def hello(name: str) -> str:
 
     """
     if name == 'nobody':
-        raise ValueError('Can not say hello to nobody')
+        msg = 'Can not say hello to nobody'
+        raise ValueError(msg)
     return f'Hello {name}!'

--- a/template/tests/test_my_module.py.jinja
+++ b/template/tests/test_my_module.py.jinja
@@ -21,6 +21,6 @@ def some_name():
     return 'Jane Smith'
 
 
-def test_hello_with_fixture(some_name):
+def test_hello_with_fixture(some_name: str):
     """Example using a fixture."""
     assert hello(some_name) == 'Hello Jane Smith!'


### PR DESCRIPTION
**Description**

`docs` directory is now ignored by `ruff`, some demo (test) code is updated to be slightly nicer, and a few additional rules are ignored for the `tests` directory, such as warning against using `assert`

- [x] I have read the [contribution guidelines](https://github.com/NLeSC/python-template/blob/main/CONTRIBUTING.md)
- [x] This update is in line with what is recommended in the [Python chapter of the Guide](https://guide.esciencecenter.nl/#/best_practices/language_guides/python)
- [x] All user facing changes have been added to CHANGELOG.md

**Related issues**:
- Fixes #446

**Instructions to review the pull request**

`pytest` should run without again issues now
