### PR TITLE
Add section for 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,27 @@
 ## Unreleased
 
 ### Added
+
 * Make zenodo next step instructions optional [#520](https://github.com/NLeSC/python-template/pull/520)
 * Make SonarCloud optional [#515](https://github.com/NLeSC/python-template/pull/515)
 * Make citation optional [#471](https://github.com/NLeSC/python-template/pull/471)
 * Make online documentation optional [#476](https://github.com/NLeSC/python-template/pull/476)
+
+### Changed
+
+* pre-commit script is optional ([#457](https://github.com/NLeSC/python-template/issues/457))
+* CHANGELOG.md is now optional ([#462](https://github.com/NLeSC/python-template/issues/462))
+
+### Removed
+
+*
+
+## 0.5.0
+
+Released on August 15, 2024
+
+### Added
+
 * Added Python 3.12 support [#356](https://github.com/NLeSC/python-template/issues/356)
 * Template unit tests for documentation generation, linting and version bumping
 * Docstring for function
@@ -16,8 +33,6 @@
 
 ### Changed
 
-* pre-commit script is optional ([#457](https://github.com/NLeSC/python-template/issues/457))
-* CHANGELOG.md is now optional ([#462](https://github.com/NLeSC/python-template/issues/462))
 * Moved to src/ based layout for generated packages
 * Moved from setup.cfg/.py to pyproject.toml [#351](https://github.com/NLeSC/python-template/issues/351)
 * Moved from prospector to ruff [#336](https://github.com/NLeSC/python-template/issues/336)
@@ -44,6 +59,8 @@
 * .zenodo.json is no longer necessary, CITATION.cff also works with Zenodo.
 
 ## 0.4.0
+
+Released on May 3, 2021
 
 ### Added
 
@@ -75,6 +92,8 @@
 
 ## 0.3.0
 
+Released on Apr 22, 2021
+
 ### Added
 
 * Added Python 3.9 support
@@ -105,6 +124,7 @@
 * Improved the documentation for the generated package and template itself
 
 ## Removed
+
 * Dropped appveyor [#160](https://github.com/NLeSC/python-template/issues/160)
 * Dropped everything Conda related
 * Drop Python 3.5 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
@@ -18,7 +18,7 @@
 
 *
 
-## 0.5.0
+## [0.5.0]
 
 Released on August 15, 2024
 
@@ -58,7 +58,7 @@ Released on August 15, 2024
 * Statements in project_setup.md already mentioned in README.dev.md
 * .zenodo.json is no longer necessary, CITATION.cff also works with Zenodo.
 
-## 0.4.0
+## [0.4.0]
 
 Released on May 3, 2021
 
@@ -90,7 +90,7 @@ Released on May 3, 2021
 
 * Automatic publish to PyPi after GitHub release [#196](https://github.com/NLeSC/python-template/issues/196)
 
-## 0.3.0
+## [0.3.0]
 
 Released on Apr 22, 2021
 
@@ -123,7 +123,7 @@ Released on Apr 22, 2021
 * Updated Code of Conduct for generated package
 * Improved the documentation for the generated package and template itself
 
-## Removed
+### Removed
 
 * Dropped appveyor [#160](https://github.com/NLeSC/python-template/issues/160)
 * Dropped everything Conda related
@@ -131,7 +131,7 @@ Released on Apr 22, 2021
 * Removed unit tests doing the linting
 
 
-## 0.2.0
+## [0.2.0]
 
 Released on July 17, 2019
 
@@ -169,7 +169,7 @@ Released on July 17, 2019
 
 * Python 2 support
 
-## 0.1.0
+## [0.1.0]
 
 Released on July 12, 2018.
 
@@ -189,3 +189,11 @@ Released on July 12, 2018.
 	- README
 	- Requirements.txt
 	- Setup configuration
+
+
+[Unreleased]: https://github.com/NLeSC/python-template//compare/0.5.0...HEAD
+[0.5.0]:      https://github.com/NLeSC/python-template/releases/tag/0.5.0
+[0.4.0]:      https://github.com/NLeSC/python-template/releases/tag/0.4.0
+[0.3.0]:      https://github.com/NLeSC/python-template/releases/tag/0.3.0
+[0.2.0]:      https://github.com/NLeSC/python-template/releases/tag/0.2.0
+[0.1.0]:      https://github.com/NLeSC/python-template/releases/tag/0.1.0


### PR DESCRIPTION
## Description

The changelog was not updated for the version 0.5.0 release, this PR
- adds a section for it,
- moves all entries since that release to that section, 
- and updates the changelog file with links as headers, similar to the style as used within the template itself


### Related Issues
- #455 


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/NLeSC/python-template/blob/main/CONTRIBUTING.md)
- [x] This update is in line with what is recommended in the [Python chapter of the Guide](https://guide.esciencecenter.nl/#/best_practices/language_guides/python)
- [x] All user facing changes have been added to CHANGELOG.md
