### PR TITLE
Make code of conduct email conditional on AddCodeConduct

### DIFF
--- a/copier/questions/features_community.yml
+++ b/copier/questions/features_community.yml
@@ -21,6 +21,16 @@ SelectCommunityFeatures:
       value: AddContributing_flag
       # validator: "{% if something != 'AnotherThing' %}BlaBla{% endif %}"
 
+code_of_conduct_email:
+  when: "{{ 'AddCodeConduct_flag' in SelectCommunityFeatures }}"
+  type: str
+  default: "{{ email }}"
+  help: What is the email address to report code of conduct violations?
+  validator: >-
+        {% if not (code_of_conduct_email | regex_search('([A-Za-z0-9]+[.-_])*[A-Za-z0-9]+@[A-Za-z0-9-]+(\.[A-Z|a-z]{2,})+')) %}
+        Please enter a valid email address
+        {% endif %}
+
 # computed features
 AddCodeConduct:
   type: bool

--- a/copier/questions/package_details.yml
+++ b/copier/questions/package_details.yml
@@ -35,14 +35,6 @@ email:
         {% if not (email | regex_search('([A-Za-z0-9]+[.-_])*[A-Za-z0-9]+@[A-Za-z0-9-]+(\.[A-Z|a-z]{2,})+')) %}
         Please enter a valid email address
         {% endif %}
-code_of_conduct_email:
-  type: str
-  default: "{{ email }}"
-  help: What is the email address to report code of conduct violations?
-  validator: >-
-        {% if not (code_of_conduct_email | regex_search('([A-Za-z0-9]+[.-_])*[A-Za-z0-9]+@[A-Za-z0-9-]+(\.[A-Z|a-z]{2,})+')) %}
-        Please enter a valid email address
-        {% endif %}
 copyright_holder:
   type: str
   default: "{{ full_name }}"


### PR DESCRIPTION
## Checklist before requesting a review
<!-- partly taken from https://axolo.co/blog/p/part-3-github-pull-request-template -->
- [x] I have read the [contribution guidelines](https://github.com/NLeSC/python-template/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] All user facing changes have been added to CHANGELOG.md
<!-- - [ ] Any dependent changes have been merged and published in downstream modules -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## List of related issues or pull requests**

<!-- add all related issues to the list below -->
Refs:
- #534

## Describe the changes made in this pull request

Move the code_of_conduct_email question to features_community.yml and only ask it if the user selected AddCodeConduct.

**Instructions to review the pull request**

<!-- remove/update what doesn't apply or add more if needed -->

Things to try:

- Use the `ask` mode and check that the e-mail question is conditional on AddCodeConduct.

Install the requirements

```
cd $(mktemp -d --tmpdir py-tmpl-XXXXXX)
pip install pipx
pipx install copier
```

Create a new package using the template

```
copier copy --vcs-ref <YOUR_BRANCH> https://github.com/nlesc/python-template test_package
```

<!-- Other steps -->
