### PR TITLE
Fix-ups for BSD licence

### DIFF
--- a/copier/questions/essential.yml
+++ b/copier/questions/essential.yml
@@ -33,7 +33,7 @@ license:
       value: Apachev2
     MIT license:
       value: MIT
-    BSD license:
+    BSD license (3-clause):
       value: BSD
     ISC license:
       value: ISC

--- a/template/{% if license == 'BSD' %}LICENSE{% endif %}.jinja
+++ b/template/{% if license == 'BSD' %}LICENSE{% endif %}.jinja
@@ -1,30 +1,29 @@
-BSD License
+BSD 3-Clause License
 
 Copyright (c) {{ '%Y' | strftime }}, {{ copyright_holder }}
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice, this
-  list of conditions and the following disclaimer in the documentation and/or
-  other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-* Neither the name of {{ package_name }} nor the names of its
-  contributors may be used to endorse or promote products derived from this
-  software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-OF THE POSSIBILITY OF SUCH DAMAGE.
-
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
## Checklist before requesting a review
<!-- partly taken from https://axolo.co/blog/p/part-3-github-pull-request-template -->
- [ ] I have read the [contribution guidelines](https://github.com/NLeSC/python-template/blob/main/CONTRIBUTING.md)
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] All user facing changes have been added to CHANGELOG.md
<!-- - [ ] Any dependent changes have been merged and published in downstream modules -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Describe the changes made in this pull request

While going through the template, I noticed a couple of small issues with the BSD licence option. Firstly, it is described just as "BSD licence", although there are two common variants: the 2-clause and 3-clause ones. (It might seem pedantic, but my institute's preferred licence is the 3-clause one, so I wanted to make sure I was using the right one!) After taking a look at the licence text, I established it was the 3-clause one, so I've changed the option to mention this in the name. There were also a couple of discrepancies between the [published text](https://opensource.org/license/bsd-3-clause) for this licence and the one in your repo, namely:

- The list of terms should be numbered
- The licence text includes the phrase "the copyright holder", which has been replaced with "`{{ package_name }}`" in yours

Not being a lawyer, I have no idea if this matters, but I thought it best to fix it up anyway. I've replaced the text with the one GitHub uses (which has also introduced some unrelated formatting changes).