### PR TITLE
Add .venv and .venv3 to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,7 @@ env
 env3
 venv
 venv3
+.venv
+.venv3
 
 .swp


### PR DESCRIPTION
These are both common names for virtual environments, so let's ignore these two. Note that this only affects the .gitignore for the repository; the one for the template already ignores these.