### PR TITLE
make copyright year/owner spacing consistently double spaced

### DIFF
--- a/template/{% if license == 'GNUv3' %}LICENSE{% endif %}.jinja
+++ b/template/{% if license == 'GNUv3' %}LICENSE{% endif %}.jinja
@@ -632,7 +632,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) {{ '%Y' | strftime }} {{ copyright_holder }}
+    Copyright (C) {{ '%Y' | strftime }}  {{ copyright_holder }}
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Checklist before requesting a review
- [x] I have read the [contribution guidelines](https://github.com/NLeSC/python-template/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings


## Type of change

Please delete options that are not relevant.

- [x] "Bug" fix (non-breaking change which fixes an issue)

## List of related issues or pull requests**


Refs:
- #685 

## Describe the changes made in this pull request

Made spacing consistent in GPLv3 license text.

**Instructions to review the pull request**

Install the requirements

```
cd $(mktemp -d --tmpdir py-tmpl-XXXXXX)
pip install pipx
pipx install copier
```

Create a new package using the template, choosing the GPLv3 license

```
copier copy --vcs-ref 685-gplv3-spacing https://github.com/nlesc/python-template test_package
```

- [ ] Confirm the spacing is now consistent at lines 635 and 655 of the LICENSE file