### PR TITLE
rename readthedocs url to documentation in pyproject.toml

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -80,7 +80,7 @@ Issues = "{{ repository_url }}/issues"
 Changelog = "{{ repository_url }}/CHANGELOG.md"
 {% endif -%}
 {% if AddOnlineDocumentation -%}
-ReadTheDocs = "https://{{ package_name }}.readthedocs.io"
+Documentation = "https://{{ package_name }}.readthedocs.io"
 {% endif %}
 {% if AddLocalTests -%}
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Checklist before requesting a review
- [x] I have read the [contribution guidelines](https://github.com/NLeSC/python-template/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## List of related issues or pull requests**

<!-- add all related issues to the list below -->
Refs:
- #478

## Describe the changes made in this pull request

Changed the 'ReadTheDocs' url name to 'Documentation' in `pyproject.toml`
