### PR TITLE
update license-related keys in pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 
+* Following [PEP 639](https://peps.python.org/pep-0639/#specification), updated `license` and `license-files` keys in `pyproject.toml` [#707](https://github.com/NLeSC/python-template/pull/707)
 * Update CI actions to use Python 3.14 instead of 3.12 [#703](https://github.com/NLeSC/python-template/pull/703)
 * Recommend `ruff format` instead of `yapf` for fixing code style readability [#695](https://github.com/NLeSC/python-template/pull/695)
 * Replace optional dependencies with dependency groups in template [#705](https://github.com/NLeSC/python-template/pull/705)

--- a/template/MANIFEST.in.jinja
+++ b/template/MANIFEST.in.jinja
@@ -1,4 +1,8 @@
-{% if AddCitation -%}include CITATION.cff{%- endif %}
+{%- if AddCitation %}
+include CITATION.cff
+{%- endif %}
 include LICENSE
+{%- if license == "Apachev2" %}
 include NOTICE
+{%- endif %}
 include README.md

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -4,7 +4,7 @@
 # - https://www.python.org/dev/peps/pep-0621/
 
 [build-system]
-requires = ["setuptools>=64.0.0", "setuptools-scm", "wheel"]
+requires = ["setuptools>=77.0.3", "setuptools-scm", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -15,13 +15,6 @@ classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "{{ {'Apache Software License 2.0': 'License :: OSI Approved :: Apache Software License',
-        'MIT license': 'License :: OSI Approved :: MIT License',
-        'BSD license': 'License :: OSI Approved :: BSD License',
-        'ISC license': 'License :: OSI Approved :: ISC License (ISCL)',
-        'GNU General Public License v3 or later': 'License :: OSI Approved :: GNU General Public License',
-        'Not open source': 'License :: Other/Proprietary License'
-    }[license] }}",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
@@ -35,7 +28,17 @@ keywords = [
 "{{ item }}"{{ "," if not loop.last }}
 {%- endfor -%}
 ]
-license = {file = "LICENSE"}
+{% if license != "Other" -%}
+license = "{{ {'Apachev2': 'Apache-2.0',
+    'MIT': 'MIT',
+    'BSD': 'BSD-3-Clause',
+    'ISC': 'ISC',
+    'GNUv3': 'GPL-3.0-or-later',
+    'GNULesserv3': 'LGPL-3.0-or-later',
+}[license] }}"
+{% endif -%}
+{#- NOTICE file is only present for Apache -#}
+license-files = ["LICENSE"{% if license == "Apachev2" %}, "NOTICE"{% endif %}]
 name = "{{ package_name }}"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.12"


### PR DESCRIPTION
## Checklist before requesting a review
<!-- partly taken from https://axolo.co/blog/p/part-3-github-pull-request-template -->
- [x] I have read the [contribution guidelines](https://github.com/NLeSC/python-template/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] All user facing changes have been added to CHANGELOG.md
<!-- - [ ] Any dependent changes have been merged and published in downstream modules -->

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
This would be technically be breaking for anyone using build tools that don't support PEP 639, although I don't expect it to be an actual problem.

## List of related issues or pull requests**

<!-- add all related issues to the list below -->
Refs:
- #706 

## Describe the changes made in this pull request

`pyproject.toml`:
- Removed license classifier from the classifiers list (no longer supported in new format, and wasn't properly configured anyway 🙈)
- Added `license-files` key, with `NOTICE` only appearing for Apache license
- Updated `license` key to specify SPDX identifier of selected license, omit key if license is "Other"

`MANIFEST.in`:
- Only include `NOTICE` for Apache license

**Instructions to review the pull request**

<!-- remove/update what doesn't apply or add more if needed -->

Install the requirements

```
<install uv>
cd $(mktemp -d --tmpdir py-tmpl-XXXXXX)
```

Create a new package using the template, selecting the various license options

```
uvx copier copy \
    https://github.com/nlesc/python-template test_package \
    --vcs-ref pep-639
```

TIP: after filling it in for the first time, save the `.copier-answers.yml` file somewhere else, remove the line with the `license` answer, and specify it as the `--data-file`, so you only have to answer the license question in future iterations:

```
uvx copier copy \
    https://github.com/nlesc/python-template test_package \
    --vcs-ref pep-639 \
    --data-file .copier-answers.yml
```

Check that `pyproject.toml` and `MANIFEST.in` are rendered correctly/nicely

```
# Create a local environment to test your generated package locally
cd test_package
less pyproject.toml
less MANIFEST.in
uvx --from build pyproject-build --installer uv

# go back to folder in /tmp, clear generated package and try again with a new license option
# cd .. && rm -rf test_package
```
